### PR TITLE
RDKEMW-5974 Build Player Integration Interface on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 3.5)
 project(Playergstinterface)
+
+set(CMAKE_CXX_STANDARD 14)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GST REQUIRED gstreamer-plugins-base-1.0)
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
@@ -72,15 +75,24 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     execute_process (
         COMMAND bash -c "xcrun --show-sdk-path" OUTPUT_VARIABLE osxSdkPath OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    set(OS_CXX_FLAGS "${OS_CXX_FLAGS}  -std=c++14 -g -x objective-c++ -Wno-inconsistent-missing-override -F${osxSdkPath}/System/Library/Frameworks")
+    set(OS_CXX_FLAGS "${OS_CXX_FLAGS}  -g -x objective-c++ -Wno-inconsistent-missing-override -F${osxSdkPath}/System/Library/Frameworks")
     set(OS_LD_FLAGS "${OS_LD_FLAGS} -F${osxSdkPath}/System/Library/Frameworks -framework Cocoa -L${osxSdkPath}/../MacOSX.sdk/usr/lib -L.libs/lib -L/usr/local/lib/")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isysroot ${osxSdkPath}/../MacOSX.sdk -I/usr/local/include")
     string(STRIP ${OS_LD_FLAGS} OS_LD_FLAGS)
+    pkg_check_modules(OPENSSL REQUIRED openssl)
+    set(LIBPLAYERGSTINTERFACE_DEPENDS ${LIBPLAYERGSTINTERFACE_DEPENDS} "${OPENSSL_LINK_LIBRARIES}")
     link_directories(${OPENSSL_LIBRARY_DIRS})
+    link_directories(${GSTREAMER_LIBRARY_DIRS})
     set(CMAKE_THREAD_LIBS_INIT "-lpthread")
     set(CMAKE_HAVE_THREADS_LIBRARY 1)
     pkg_check_modules(GLIB REQUIRED GLib-2.0)
     include_directories(${GLIB_INCLUDE_DIRS})
+    pkg_check_modules(LIBCJSON REQUIRED libcjson)
+    include_directories(${LIBCJSON_INCLUDE_DIRS})
+    set(LIBPLAYERGSTINTERFACE_DEPENDS ${LIBPLAYERGSTINTERFACE_DEPENDS} "${LIBCJSON_LINK_LIBRARIES}")
+    # This is .libs/lib/pkgconfig which picks up all locally built dependencies
+    link_directories(${LIBCJSON_LIBRARY_DIRS})
+    #link_directories(".libs/lib")
 
     # XCode build flags. Even when using CLANG, the GCC name is required to enable the check
     set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION "YES")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-declare DEFAULT_OPENSSL_VERSION="openssl@3.4"
+declare DEFAULT_OPENSSL_VERSION="openssl@3.5"
 
 function install_pkgs_pkgconfig_darwin_fn() 
 {
@@ -198,8 +198,8 @@ function install_pkgs_fn()
           brew update
       fi
 
-      install_pkgs_darwin_fn git json-glib cmake "openssl@3.4" libxml2 ossp-uuid cjson gnu-sed jpeg-turbo taglib speex mpg123 meson ninja pkg-config flac asio jsoncpp lcov gcovr jq curl
-      install_pkgs_darwin_fn coreutils websocketpp "boost@1.85" jansson libxkbcommon cppunit gnu-sed fontconfig doxygen graphviz tinyxml2 openldap krb5
+      install_pkgs_darwin_fn git json-glib cmake ${DEFAULT_OPENSSL_VERSION} libxml2 ossp-uuid cjson gnu-sed jpeg-turbo taglib speex mpg123 meson ninja pkg-config flac asio jsoncpp lcov gcovr jq curl
+      install_pkgs_darwin_fn coreutils websocketpp "boost@1.85" jansson libxkbcommon cppunit gnu-sed fontconfig doxygen graphviz tinyxml2 openldap krb5 wavpack gettext
 
       # ORC causes compile errors on x86_64 Mac, but not on ARM64
       if [[ $ARCH == "x86_64" ]]; then

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # default values
-OPTION_PLAYER_BRANCH="dev_sprint_25_1"
+OPTION_PLAYER_BRANCH="develop"
 OPTION_BUILD_DIR=""
 OPTION_BUILD_ARGS=""
 OPTION_CLEAN=false

--- a/scripts/install_subtec.sh
+++ b/scripts/install_subtec.sh
@@ -43,6 +43,13 @@ function subtec_install_fn() {
     
     sed -i ${SED_ARG} 's:COMMAND gdbus-codegen --interface-prefix com.libertyglobal.rdk --generate-c-code TeletextDbusInterface ${CMAKE_CURRENT_SOURCE_DIR}/api/dbus/TeletextDbusInterface.xml:COMMAND '"${2}"'/glib/build/gio/gdbus-2.0/codegen/gdbus-codegen --interface-prefix com.libertyglobal.rdk --generate-c-code TeletextDbusInterface ${CMAKE_CURRENT_SOURCE_DIR}/api/dbus/TeletextDbusInterface.xml:g' subttxrend-dbus/CMakeLists.txt
     
+    echo "Update asio::service to asio::context"
+    sed -i ${SED_ARG} 's/asio::io_service/asio::io_context/g'  websocket-ipplayer2-utils/src/ipp2/servers/SimpleWebServer.cpp
+    sed -i ${SED_ARG} 's/asio::ip::address::from_string/asio::ip::make_address/g'  websocket-ipplayer2-utils/src/ipp2/servers/SimpleWebServer.cpp
+    sed -i ${SED_ARG} 's/\([a-zA-Z0-9_]*\)->reset()/\1->restart()/g'  websocket-ipplayer2-utils/src/ipp2/servers/SimpleWebServer.cpp
+    sed -i ${SED_ARG} 's/\([a-zA-Z0-9_]*\)->post(/asio::post(*\1, /g'  websocket-ipplayer2-utils/src/ipp2/servers/SimpleWebServer.cpp
+    
+
     echo "subtec-app source prepared"
     popd
 }


### PR DESCRIPTION
Reason for change: Correct install-middleware.sh errors on MacOS
Test Procedure: Run install-middleware.sh on Ubuntu and MacOS, should build sucessfully.

Risks: Low
Priority: P2