### PR TITLE
RDKEMW-5868 Native build workflow added for coverity

### DIFF
--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: native build
+         apt-get install sudo
         run: yes | ./install-middleware.sh -s subtec
         env:
           GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
          apt-get update
          apt-get install -y sudo
+         sudo apt-get install -y python3-pip
+         sudo apt remove -y meson || true
+         sudo pip3 install --upgrade meson
+         hash -r
          yes | ./install-middleware.sh -s subtec
         env:
           GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -9,8 +9,8 @@ jobs:
   build-player-interface-on-pr:
     name: Build player-interface component in github rdkcentral
     runs-on: ubuntu-latest
-    #container:
-     # image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+    container:
+     image: ghcr.io/rdkcentral/docker-rdk-ci:latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -17,4 +17,6 @@ jobs:
         uses: actions/checkout@v3
       
       - name: native build
-        run: yes | ./install-middleware.sh -s subtec
+        run: yes | ./install-middleware.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v3
       
       - name: native build
-        run: yes | ./install-middleware.sh
+        run: yes | ./install-middleware.sh -s subtec
         env:
           GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/native-full-build.yml
+++ b/.github/workflows/native-full-build.yml
@@ -17,7 +17,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: native build
-         apt-get install sudo
-        run: yes | ./install-middleware.sh -s subtec
+        run: |
+         apt-get update
+         apt-get install -y sudo
+         yes | ./install-middleware.sh -s subtec
         env:
           GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/GstUtils.cpp
+++ b/GstUtils.cpp
@@ -120,4 +120,3 @@ void PlayerCliGstTerm()
 {
 	gst_deinit();
 }
-


### PR DESCRIPTION
Reason for change: Updated native-full-build workflow to remove subtec flag and add GITHUB_TOKEN
Test Procedure: None

Risks: Low
Priority: P1