### PR TITLE
VPLAY-11276 : Inconsistent event names in InterfacePlayerRDK

### DIFF
--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -3628,7 +3628,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 
 	if (eGST_MEDIATYPE_VIDEO == mediaType)
 	{
-		MW_LOG_MIL("InterfacePlayerRDK_OnFirstVideoFrameCallback. got First Video Frame");
+		MW_LOG_MIL("OnFirstVideoFrame. got First Video Frame");
 
 		if (!interfacePlayerPriv->gstPrivateContext->decoderHandleNotified)
 		{
@@ -3655,7 +3655,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 	}
 	else if (eGST_MEDIATYPE_AUDIO == mediaType)
 	{
-		MW_LOG_MIL("InterfacePlayerRDK_OnAudioFirstFrameAudDecoder. got First Audio Frame");
+		MW_LOG_MIL("OnAudioFirstFrame. got First Audio Frame");
 		if (audioOnly)
 		{
 			if (!interfacePlayerPriv->gstPrivateContext->decoderHandleNotified)

--- a/playerLogManager/PlayerLogManager.cpp
+++ b/playerLogManager/PlayerLogManager.cpp
@@ -103,7 +103,7 @@ void logprintf(MW_LogLevel logLevelIndex, const char* file, int line, const char
         for( int pass=0; pass<2; pass++ )
         {
             format_bytes = snprintf(format_ptr, format_bytes,
-                                                           "%s[MIDDLEWARE][%s][%zx][%s][%d]%s\n",
+                                                           "%s[PLAYER_IF][%s][%zx][%s][%d]%s\n",
                                                            timestamp,
                                                            mLogLevelStr[logLevelIndex],
 							   GetPlayerPrintableThreadID(),


### PR DESCRIPTION
Reason for change: Standardized audio/video frame event names.
Test Procedure: No Test required
Priority: P1