### PR TITLE
RDK-58999 : Metrics Collection for Player Interface Public APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ if(DISABLE_SECURITY_TOKEN)
 	add_definitions(-DDISABLE_SECURITY_TOKEN)
 endif()
 
+option(ENABLE_MW_PROFILING "Enable middleware profiling" ON)
+
+if(ENABLE_MW_PROFILING)
+  add_definitions(-DENABLE_MW_PROFILING)
+endif()
+
 # Option for building pi-cli
 option(BUILD_PICLI "Build the pi-cli test project" OFF)
 
@@ -161,6 +167,9 @@ set(LIBPLAYERGSTINTERFACE_HEADERS
 	subtitle/vttCue.h
 	ProcessHandler.h
 )
+if(ENABLE_MW_PROFILING)
+    list(APPEND LIBPLAYERGSTINTERFACE_HEADERS PerfProfiler.h)
+endif()
 
 install(FILES closedcaptions/CCTrackInfo.h
 	PlayerScheduler.h
@@ -199,6 +208,10 @@ install(FILES closedcaptions/CCTrackInfo.h
 	playerisobmff/playerisobmffbox.h
 	DESTINATION include)
 
+if(ENABLE_MW_PROFILING)
+    install(FILES PerfProfiler.h DESTINATION include)
+endif()
+
 set(SOURCES
 	InterfacePlayerRDK.cpp
 	SocUtils.cpp
@@ -212,6 +225,10 @@ set(SOURCES
 	drm/processProtectionHls.cpp
 	ProcessHandler.cpp
 )
+
+if(ENABLE_MW_PROFILING)
+    list(APPEND SOURCES PerfProfiler.cpp)
+endif()
 
 if(NOT (CMAKE_PLATFORM_UBUNTU OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
 	list(APPEND SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
+#
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -35,6 +35,7 @@
 #include "player-xternal-stats.h"
 #endif
 #include "PlayerUtils.h"
+#include "PerfProfiler.h"
 
 #define DEFAULT_BUFFERING_TO_MS 10                       /**< TimeOut interval to check buffer fullness */
 #define DEFAULT_BUFFERING_MAX_MS (1000)                  /**< max buffering time */
@@ -261,6 +262,7 @@ void InterfacePlayerRDK::ConfigurePipeline(int format, int audioFormat, int subF
 										   bool bESChangeStatus, bool setReadyAfterPipelineCreation,
 										   bool isSubEnable, int32_t trackId, gint rate, const char *pipelineName, int PipelinePriority, bool FirstFrameFlag, std::string manifestUrl)
 {
+	MW_PROFILE_FUNCTION();
 	mFirstFrameRequired = FirstFrameFlag;
 	GstStreamOutputFormat gstFormat 	= static_cast<GstStreamOutputFormat>(format);
 	GstStreamOutputFormat gstAudioFormat 	= static_cast<GstStreamOutputFormat>(audioFormat);
@@ -506,6 +508,7 @@ static GstBusSyncReply bus_sync_handler(GstBus * bus, GstMessage * msg, Interfac
 
 void InterfacePlayerRDK::SetPauseOnStartPlayback(bool enable)
 {
+	MW_PROFILE_FUNCTION();
 	interfacePlayerPriv->gstPrivateContext->pauseOnStartPlayback = enable;
 }
 
@@ -553,6 +556,7 @@ static void GstPlayer_OnFirstVideoFrameCallback(GstElement* object, guint arg0, 
  */
 const MonitorAVState& InterfacePlayerRDK::GetMonitorAVState()
 {
+	MW_PROFILE_FUNCTION();
 	return interfacePlayerPriv->gstPrivateContext->monitorAVstate;
 }
 
@@ -799,6 +803,7 @@ bool gst_StartsWith( const char *inputStr, const char *prefix );
  */
 void InterfacePlayerRDK::setEncryption(void *Encrypt, void *DRMSessionManager)
 {
+	MW_PROFILE_FUNCTION();
 	mEncrypt = Encrypt;
 	mDRMSessionManager = DRMSessionManager;
 }
@@ -809,6 +814,7 @@ void InterfacePlayerRDK::setEncryption(void *Encrypt, void *DRMSessionManager)
  */
 void InterfacePlayerRDK::SetPreferredDRM(const char *drmID)
 {
+	MW_PROFILE_FUNCTION();
 	if (drmID != NULL)
 	{
 		if (mDrmSystem != NULL)
@@ -1036,6 +1042,7 @@ void InterfacePlayerRDK::RemoveProbe(int type)
  */
 void InterfacePlayerRDK::DestroyPipeline()
 {
+	MW_PROFILE_FUNCTION();
 	if (interfacePlayerPriv->gstPrivateContext->pipeline)
 	{
 		/*"Destroying gstreamer pipeline" should only be logged when there is a pipeline to destroy
@@ -1358,6 +1365,7 @@ void InterfacePlayerRDK::TearDownStream(int type)
 
 void InterfacePlayerRDK::Stop(bool keepLastFrame)
 {
+	MW_PROFILE_FUNCTION();
 	std::lock_guard<std::mutex> lock(mMutex);
 	/*  make the execution of this function more deterministic and
 	 *  reduce scope for potential pipeline lockups*/
@@ -1526,6 +1534,7 @@ bool InterfacePlayerRDK::IsUsingRialtoSink()
  */
 bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek)
 {
+	MW_PROFILE_FUNCTION();
 	GstState aud_current;
 	GstState aud_pending;
 	GstState current;
@@ -2518,11 +2527,13 @@ gboolean InterfacePlayerPriv::SendQtDemuxOverrideEvent(int mediaType, GstClockTi
  */
 std::string InterfacePlayerRDK::GetVideoRectangle()
 {
+	MW_PROFILE_FUNCTION();
 	return std::string(interfacePlayerPriv->gstPrivateContext->videoRectangle);
 }
 
 void InterfacePlayerRDK::SetSubtitlePtsOffset(std::uint64_t pts_offset)
 {
+	MW_PROFILE_FUNCTION();
 	if (interfacePlayerPriv->gstPrivateContext->usingRialtoSink)
 	{
 		if(interfacePlayerPriv->gstPrivateContext->stream[eGST_MEDIATYPE_SUBTITLE].source)
@@ -2557,6 +2568,7 @@ void InterfacePlayerRDK::ResetFirstFrame(void)
 
 GstPlaybackQualityStruct* InterfacePlayerRDK::GetVideoPlaybackQuality(void)
 {
+	MW_PROFILE_FUNCTION();
 	GstStructure *stats= 0;
 	GstElement *element;
 	if((interfacePlayerPriv->socInterface->IsPlaybackQualityFromSink()))
@@ -2600,6 +2612,7 @@ GstPlaybackQualityStruct* InterfacePlayerRDK::GetVideoPlaybackQuality(void)
  */
 long long InterfacePlayerRDK::GetPositionMilliseconds(void)
 {
+	MW_PROFILE_FUNCTION();
 	long long rc = 0;
 	if (interfacePlayerPriv->gstPrivateContext->pipeline == NULL)
 	{
@@ -2672,6 +2685,7 @@ long long InterfacePlayerRDK::GetPositionMilliseconds(void)
  */
 long InterfacePlayerRDK::GetDurationMilliseconds(void)
 {
+	MW_PROFILE_FUNCTION();
 	long rc = 0;
 	if( interfacePlayerPriv->gstPrivateContext->pipeline )
 	{
@@ -2716,6 +2730,7 @@ long InterfacePlayerRDK::GetDurationMilliseconds(void)
  */
 void InterfacePlayerRDK::GetVideoSize(int &width, int &height)
 {
+	MW_PROFILE_FUNCTION();
 	int x;
 	int y;
 	int w = 0;
@@ -2729,6 +2744,7 @@ void InterfacePlayerRDK::GetVideoSize(int &width, int &height)
 
 void InterfacePlayerRDK::SetSubtitleMute(bool muted)
 {
+	MW_PROFILE_FUNCTION();
 	interfacePlayerPriv->gstPrivateContext->subtitleMuted = muted;
 	if (interfacePlayerPriv->gstPrivateContext->subtitle_sink)
 	{
@@ -2744,6 +2760,7 @@ void InterfacePlayerRDK::SetSubtitleMute(bool muted)
  */
 void InterfacePlayerRDK::SetVideoRectangle(int x, int y, int w, int h)
 {
+	MW_PROFILE_FUNCTION();
 	int currentX = 0, currentY = 0, currentW = 0, currentH = 0;
 	if (strcmp(interfacePlayerPriv->gstPrivateContext->videoRectangle, "") != 0)
 	{
@@ -2781,6 +2798,7 @@ void InterfacePlayerRDK::SetVideoRectangle(int x, int y, int w, int h)
  */
 bool InterfacePlayerRDK::StopBuffering(bool forceStop, bool &isPlaying)
 {
+	MW_PROFILE_FUNCTION();
 	bool sendEndEvent = false;
 	if (interfacePlayerPriv->gstPrivateContext->video_dec)
 	{
@@ -2832,6 +2850,7 @@ bool InterfacePlayerRDK::StopBuffering(bool forceStop, bool &isPlaying)
  */
 unsigned long InterfacePlayerRDK::GetCCDecoderHandle()
 {
+	MW_PROFILE_FUNCTION();
 	gpointer dec_handle = NULL;
 
 	if (interfacePlayerPriv->gstPrivateContext->usingClosedCaptionsControl)
@@ -2899,6 +2918,7 @@ bool InterfacePlayerRDK::WaitForSourceSetup(int mediaType)
 
 bool InterfacePlayerRDK::HandleVideoBufferSent()
 {
+	MW_PROFILE_FUNCTION();
 	bool isFirstBuffer = (interfacePlayerPriv->gstPrivateContext->numberOfVideoBuffersSent == 0);
 	interfacePlayerPriv->gstPrivateContext->numberOfVideoBuffersSent++;
 	return isFirstBuffer;
@@ -2906,6 +2926,7 @@ bool InterfacePlayerRDK::HandleVideoBufferSent()
 
 void InterfacePlayerRDK::SetPlayerName(std::string name)
 {
+	MW_PROFILE_FUNCTION();
 	interfacePlayerPriv->mPlayerName = name;
 }
 
@@ -2914,6 +2935,7 @@ void InterfacePlayerRDK::SetPlayerName(std::string name)
  */
 bool InterfacePlayerRDK::SendHelper(int type, const void *ptr, size_t len, double fpts, double fdts, double fDuration, double fragmentPTSoffset, bool copy, bool initFragment, bool &discontinuity, bool &notifyFirstBufferProcessed, bool &sendNewSegmentEvent, bool &resetTrickUTC, bool &firstBufferPushed)
 {
+	MW_PROFILE_FUNCTION();
 	GstMediaType mediaType = static_cast<GstMediaType>(type);
 	GstClockTime pts = (GstClockTime)(fpts * GST_SECOND);
 	GstClockTime dts = (GstClockTime)(fdts * GST_SECOND);
@@ -3146,12 +3168,14 @@ bool InterfacePlayerRDK::SendHelper(int type, const void *ptr, size_t len, doubl
 
 void InterfacePlayerRDK::PauseInjector()
 {
+	MW_PROFILE_FUNCTION();
 	std::unique_lock<std::mutex> lock(mSourceSetupMutex);
 	mPauseInjector = true;
 }
 
 void InterfacePlayerRDK::ResumeInjector()
 {
+	MW_PROFILE_FUNCTION();
 	std::unique_lock<std::mutex> lock(mSourceSetupMutex);
 	mPauseInjector = false;
 	mSourceSetupCV.notify_all();
@@ -3223,6 +3247,7 @@ void InterfacePlayerPriv::SendNewSegmentEvent(int type, GstClockTime startPts ,G
  */
 void InterfacePlayerRDK::QueueProtectionEvent(const std::string& formatType, const char *protSystemId, const void *initData, size_t initDataSize, int mediaType)
 {
+	MW_PROFILE_FUNCTION();
 	/* There is a possibility that only single protection event is queued for multiple type since they are encrypted using same id.
 	 * Don't worry if you see only one protection event queued here.
 	 */
@@ -3257,6 +3282,7 @@ void InterfacePlayerRDK::QueueProtectionEvent(const std::string& formatType, con
  */
 void InterfacePlayerRDK::ClearProtectionEvent()
 {
+	MW_PROFILE_FUNCTION();
 	pthread_mutex_lock(&mProtectionLock);
 	for (int i = 0; i < GST_TRACK_COUNT; i++)
 	{
@@ -3309,6 +3335,7 @@ static GstState validateStateWithMsTimeout( InterfacePlayerRDK *pInterfacePlayer
  */
 bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 {
+	MW_PROFILE_FUNCTION();
 	bool retValue = true;
 	if (interfacePlayerPriv->gstPrivateContext->pipeline != NULL)
 	{
@@ -3360,6 +3387,7 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
  */
 bool InterfacePlayerRDK::CheckForPTSChangeWithTimeout(long timeout)
 {
+	MW_PROFILE_FUNCTION();
 	bool ret = true;
 	gint64 currentPTS = GetVideoPTS();			/* Gets the currentPTS from the 'video-pts' property of the element */
 	if (currentPTS != 0)
@@ -3393,6 +3421,7 @@ bool InterfacePlayerRDK::CheckForPTSChangeWithTimeout(long timeout)
  */
 bool InterfacePlayerRDK::IsCacheEmpty(int Type)
 {
+	MW_PROFILE_FUNCTION();
 	GstMediaType mediaType = (GstMediaType)Type;
 	bool ret = true;
 	gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[mediaType];
@@ -3447,6 +3476,7 @@ void InterfacePlayerRDK::ResetEOSSignalledFlag()
  */
 bool InterfacePlayerRDK::PipelineConfiguredForMedia(int type)
 {
+	MW_PROFILE_FUNCTION();
 	bool pipelineConfigured = true;
 
 	gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[type];
@@ -3459,6 +3489,7 @@ bool InterfacePlayerRDK::PipelineConfiguredForMedia(int type)
 
 bool InterfacePlayerRDK::GetBufferControlData(int iMediaType)
 {
+	MW_PROFILE_FUNCTION();
 	bool GstWaitingForData = false;
 	GstState current;
 	GstState pending;
@@ -3482,6 +3513,7 @@ bool InterfacePlayerRDK::GetBufferControlData(int iMediaType)
 }
 bool InterfacePlayerRDK::IsStreamReady(int mediaType)
 {
+	MW_PROFILE_FUNCTION();
 	bool StreamReady = false;
 
 	const gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[mediaType];
@@ -3494,7 +3526,7 @@ bool InterfacePlayerRDK::IsStreamReady(int mediaType)
  */
 void InterfacePlayerRDK::SignalTrickModeDiscontinuity()
 {
-
+	MW_PROFILE_FUNCTION();
 	gst_media_stream* stream = &interfacePlayerPriv->gstPrivateContext->stream[eGST_MEDIATYPE_VIDEO];
 	if (stream && (interfacePlayerPriv->gstPrivateContext->rate != GST_NORMAL_PLAY_RATE) )
 	{
@@ -3526,6 +3558,7 @@ void InterfacePlayerRDK::EnableGstDebugLogging(std::string debugLevel)
  */
 bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bool codecChange, bool &unblockDiscProcess, bool &shouldHaltBuffering)
 {
+	MW_PROFILE_FUNCTION();
 	bool ret = false;
 	GstMediaType type = (GstMediaType)mediaType;
 	gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[type];
@@ -3929,6 +3962,7 @@ bool InterfacePlayerRDK::CreatePipeline(const char *pipelineName, int PipelinePr
  */
 long long InterfacePlayerRDK::GetVideoPTS(void)
 {
+	MW_PROFILE_FUNCTION();
 	gint64 currentPTS = 0;
 	currentPTS = interfacePlayerPriv->socInterface->GetVideoPts(interfacePlayerPriv->gstPrivateContext->video_sink, interfacePlayerPriv->gstPrivateContext->video_dec, interfacePlayerPriv->gstPrivateContext->using_westerossink);
 	return (long long)currentPTS;
@@ -4433,6 +4467,7 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 
 bool InterfacePlayerRDK::SetPlayBackRate(double rate)
 {
+	MW_PROFILE_FUNCTION();
 	bool ret = false;
 	std::vector<GstElement*> sources;
 	MW_LOG_TRACE("InterfacePlayerRDK: gst_event_new_instant_rate_change: %f ...V6", rate);
@@ -4452,6 +4487,7 @@ bool InterfacePlayerRDK::SetPlayBackRate(double rate)
  */
 void InterfacePlayerRDK::SetAudioVolume(int volume)
 {
+	MW_PROFILE_FUNCTION();
 	interfacePlayerPriv->gstPrivateContext->audioVolume = static_cast<double>(volume) / 100.0;
 }
 
@@ -4460,6 +4496,7 @@ void InterfacePlayerRDK::SetAudioVolume(int volume)
  */
 void InterfacePlayerRDK::SetVolumeOrMuteUnMute(void)
 {
+	MW_PROFILE_FUNCTION();
 	const std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->volumeMuteMutex);
 	GstElement *gSource = nullptr;
 	const char *mutePropertyName = nullptr;
@@ -4596,6 +4633,7 @@ static gboolean buffering_timeout (gpointer data)
  */
 void InterfacePlayerRDK::SetVideoZoom(int zoom_mode)
 {
+	MW_PROFILE_FUNCTION();
 	MW_LOG_MIL(" SetVideoZoom :: ZoomMode %d, video_sink =%p",zoom_mode, interfacePlayerPriv->gstPrivateContext->video_sink);
 
 	interfacePlayerPriv->gstPrivateContext->zoom = static_cast<GstVideoZoomMode>(zoom_mode);
@@ -4614,6 +4652,7 @@ void InterfacePlayerRDK::SetVideoZoom(int zoom_mode)
  */
 void InterfacePlayerRDK::SetVideoMute(bool muted)
 {
+	MW_PROFILE_FUNCTION();
 	MW_LOG_INFO("muted=%d video_sink =%p", muted, interfacePlayerPriv->gstPrivateContext->video_sink);
 	interfacePlayerPriv->gstPrivateContext->videoMuted = muted;
 	if (interfacePlayerPriv->gstPrivateContext->video_sink)
@@ -4631,6 +4670,7 @@ void InterfacePlayerRDK::SetVideoMute(bool muted)
  */
 bool InterfacePlayerRDK::SetTextStyle(const std::string &options)
 {
+	MW_PROFILE_FUNCTION();
 	bool ret = false;
 	if (interfacePlayerPriv->gstPrivateContext->subtitle_sink)
 	{
@@ -4955,6 +4995,7 @@ void InterfacePlayerRDK::NotifyEOS()
  */
 void InterfacePlayerRDK::NotifyFragmentCachingComplete()
 {
+	MW_PROFILE_FUNCTION();
 	if(interfacePlayerPriv->gstPrivateContext->pendingPlayState)
 	{
 		MW_LOG_MIL("InterfacePlayer: Setting pipeline to PLAYING state ");
@@ -4976,6 +5017,7 @@ void InterfacePlayerRDK::NotifyFragmentCachingComplete()
  */
 void InterfacePlayerRDK::EndOfStreamReached(int mediaType, bool &shouldHaltBuffering)
 {
+	MW_PROFILE_FUNCTION();
 	MW_LOG_MIL("entering InterfacePlayer_EndOfStreamReached type %d", mediaType);
 	GstMediaType type = static_cast<GstMediaType>(mediaType);
 
@@ -5034,6 +5076,7 @@ int InterfacePlayerRDK::InterfacePlayer_SetupStream(int streamId, std::string ma
 
 void InterfacePlayerRDK::DisableDecoderHandleNotified()
 {
+	MW_PROFILE_FUNCTION();
 	interfacePlayerPriv->gstPrivateContext->decoderHandleNotified = false;
 }
 
@@ -5221,6 +5264,7 @@ void InterfacePlayerRDK::InitializePlayerGstreamerPlugins()
  */
 double InterfacePlayerRDK::FlushTrack(int mediaType, double pos, double audioDelta, double subDelta)
 {
+	MW_PROFILE_FUNCTION();
 	double startPosition = 0;
 	GstMediaType type = static_cast<GstMediaType>(mediaType);
 

--- a/PerfProfiler.cpp
+++ b/PerfProfiler.cpp
@@ -9,7 +9,10 @@ ScopedTimer::ScopedTimer(const std::string& funcName, const std::string& fileNam
 ScopedTimer::~ScopedTimer() {
     auto end = std::chrono::high_resolution_clock::now();
     long long duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-    std::cout << "[PERF] " << name << " (Thread " << std::this_thread::get_id()
-              << ") took " << duration << " µs\n";
+	MW_LOG_INFO(MW_LOG_PERF, "[PERF] %s (Thread %zu) took %lld us",
+        name.c_str(),
+        std::hash<std::thread::id>{}(std::this_thread::get_id()),
+        duration
+    );
 }
 

--- a/PerfProfiler.cpp
+++ b/PerfProfiler.cpp
@@ -1,0 +1,15 @@
+#include "PerfProfiler.h"
+#include <iostream>
+#include <thread>
+
+ScopedTimer::ScopedTimer(const std::string& funcName, const std::string& fileName, int line)
+    : name(funcName + " [" + fileName + ":" + std::to_string(line) + "]"),
+      start(std::chrono::high_resolution_clock::now()) {}
+
+ScopedTimer::~ScopedTimer() {
+    auto end = std::chrono::high_resolution_clock::now();
+    long long duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+    std::cout << "[PERF] " << name << " (Thread " << std::this_thread::get_id()
+              << ") took " << duration << " µs\n";
+}
+

--- a/PerfProfiler.h
+++ b/PerfProfiler.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <chrono>
+#include "PlayerLogManager.h"
 
 #ifdef ENABLE_MW_PROFILING
 

--- a/PerfProfiler.h
+++ b/PerfProfiler.h
@@ -1,0 +1,28 @@
+#ifndef PERF_PROFILER_H
+#define PERF_PROFILER_H
+
+#include <string>
+#include <chrono>
+
+#ifdef ENABLE_MW_PROFILING
+
+class ScopedTimer {
+public:
+    ScopedTimer(const std::string& funcName, const std::string& fileName, int line);
+    ~ScopedTimer();
+
+private:
+    std::string name;
+    std::chrono::high_resolution_clock::time_point start;
+};
+
+// Macro for easy integration
+#define MW_PROFILE_FUNCTION() ScopedTimer timer(__FUNCTION__, __FILE__, __LINE__)
+
+#else
+
+#define MW_PROFILE_FUNCTION() //profiling disabled
+
+#endif //ENABLE_MW_PROFILING
+#endif // PERF_PROFILER_H
+


### PR DESCRIPTION
RDK-58999 : Metrics Collection for Player Interface Public APIs
Reason for change : Adding functions to get the execution time of all player interface public APIs.
Priority : P1
Risks : None
Signed-off-by : nejumathoppil_nazar@comcast.com