### PR TITLE
RDKEMW-12481 Fix PI-CLI build issues

### DIFF
--- a/test/pi-cli/CMakeLists.txt
+++ b/test/pi-cli/CMakeLists.txt
@@ -43,7 +43,12 @@ find_package(OpenSSL REQUIRED)
 target_link_libraries(pi-cli playergstinterface OpenSSL::Crypto OpenSSL::SSL)
 if(BUILD_WITH_COVERAGE)
     target_compile_options(pi-cli PRIVATE --coverage)
-    target_link_options(pi-cli PRIVATE --coverage)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
+        target_link_options(pi-cli PRIVATE --coverage)
+    else()
+        # Fallback for older CMake versions that do not support target_link_options
+        set_target_properties(pi-cli PROPERTIES LINK_FLAGS "--coverage")
+    endif()
     message(STATUS "pi-cli: Building with coverage instrumentation")
 endif()
 

--- a/test/pi-cli/CMakeLists.txt
+++ b/test/pi-cli/CMakeLists.txt
@@ -11,6 +11,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 include_directories(${PI_ROOT})
 
+# Find GStreamer packages
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
+pkg_check_modules(GSTREAMERBASE REQUIRED gstreamer-app-1.0)
+
+include_directories(${GSTREAMER_INCLUDE_DIRS})
+include_directories(${GSTREAMERBASE_INCLUDE_DIRS})
+
 # Add the executable (now includes commandProcessing.cpp)
 add_executable(pi-cli
     main.cpp
@@ -29,7 +37,15 @@ else()
     message(FATAL_ERROR "Readline library not found. Please install it.")
 endif()
 
-target_link_libraries(pi-cli playergstinterface)
+# Add OpenSSL requirement so we can link crypto/ssl symbols
+find_package(OpenSSL REQUIRED)
+
+target_link_libraries(pi-cli playergstinterface OpenSSL::Crypto OpenSSL::SSL)
+if(BUILD_WITH_COVERAGE)
+    target_compile_options(pi-cli PRIVATE --coverage)
+    target_link_options(pi-cli PRIVATE --coverage)
+    message(STATUS "pi-cli: Building with coverage instrumentation")
+endif()
 
 # Additional warnings and flags for development
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/test/pi-cli/CMakeLists.txt
+++ b/test/pi-cli/CMakeLists.txt
@@ -26,7 +26,6 @@ add_executable(pi-cli
 )
 
 # Use pkg-config to locate the readline library
-find_package(PkgConfig REQUIRED)
 pkg_check_modules(READLINE REQUIRED readline)
 
 if (READLINE_FOUND)

--- a/test/pi-cli/commandProcessing.cpp
+++ b/test/pi-cli/commandProcessing.cpp
@@ -612,7 +612,7 @@ std::map<std::string, Command> initializeCommands(CommandExecutor& executor, Int
     commands.emplace("setaudiovolume", Command("setaudiovolume", "Set audio volume. Usage: setaudiovolume <volume>", [&player](const std::vector<std::string>& params) { setAudioVolumeCommand(player, params); }));
     commands.emplace("setupstream", Command("setupstream", "Setup stream. Usage: setupstream <streamId> <playerInstance(int)> <url>", [&player](const std::vector<std::string>& params) { setupStreamCommand(player, params); }));
     commands.emplace("pause", Command("pause", "Pause the pipeline. Usage: pause [pause(bool)] [forceStop(bool)]", [&player](const std::vector<std::string>& params) { pauseCommand(player, params); }));
-    commands.emplace("resume", Command("resume", "Resume playback.\nUsage: resume", [&player](const std::vector<std::string>& params) { resumeCommand(player, params); }));
+    commands.emplace("resume", Command("resume", "Resume playback. Usage: resume", [&player](const std::vector<std::string>& params) { resumeCommand(player, params); }));
     commands.emplace("resumeinjector", Command("resumeinjector", "Resume injector.", [&player](const std::vector<std::string>& params) { resumeInjectorCommand(player, params); }));
     commands.emplace("stop", Command("stop", "Stop playback.", [&player](const std::vector<std::string>& params) { stopCommand(player, params); }));
     commands.emplace("flush", Command("flush", "Flush pipeline.", [&player](const std::vector<std::string>& params) { flushCommand(player, params); }));

--- a/test/pi-cli/commandProcessing.cpp
+++ b/test/pi-cli/commandProcessing.cpp
@@ -185,8 +185,8 @@ void initializeSourceForPlayerCommand(InterfacePlayerRDK& player, const std::vec
 void configurePipelineCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params) {
     // The signature from InterfacePlayerRDK.h:
     // void ConfigurePipeline(int, int, int, int, bool, bool, bool, bool, int32_t, gint, const char *, int, bool, std::string url);
-    if (params.size() != 14) {
-        std::cout << "Usage: configurepipeline <int> <int> <int> <int> <bool> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>\n";
+    if (params.size() != 12) {
+        std::cout << "Usage: configurepipeline <int> <int> <int> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>\n";
         return;
     }
 
@@ -215,7 +215,7 @@ void configurePipelineCommand(InterfacePlayerRDK& player, const std::vector<std:
         std::cout << "ConfigurePipeline executed.\n";
     } catch (const std::exception& e) {
         std::cout << "Error parsing parameters: " << e.what() << "\n";
-        std::cout << "Usage: configurepipeline <int> <int> <int> <int> <bool> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>\n";
+        std::cout << "Usage: configurepipeline <int> <int> <int> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>\n";
     }
 }
 
@@ -608,7 +608,7 @@ std::map<std::string, Command> initializeCommands(CommandExecutor& executor, Int
     commands.emplace("setplayername", Command("setplayername", "Set player name. Usage: setplayername <name>", [&player](const std::vector<std::string>& params) { setPlayerNameCommand(player, params); }));
     commands.emplace("setpreferreddrm", Command("setpreferreddrm", "Set preferred DRM. Usage: setpreferreddrm <drmID>", [&player](const std::vector<std::string>& params) { setPreferredDRMCommand(player, params); }));
     commands.emplace("initializesourceforplayer", Command("initializesourceforplayer", "Initialize source. Usage: initializesourceforplayer <playerInstance(int)> <source(int)> <mediaType>", [&player](const std::vector<std::string>& params) { initializeSourceForPlayerCommand(player, params); }));
-    commands.emplace("configurepipeline", Command("configurepipeline", "Configure pipeline. Usage: configurepipeline <int> <int> <int> <int> <bool> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>", [&player](const std::vector<std::string>& params) { configurePipelineCommand(player, params); }));
+    commands.emplace("configurepipeline", Command("configurepipeline", "Configure pipeline. Usage: configurepipeline <int> <int> <int> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>", [&player](const std::vector<std::string>& params) { configurePipelineCommand(player, params); }));
     commands.emplace("setpauseonstart", Command("setpauseonstart", "Enable/disable pause on start playback. Usage: setpauseonstart [true|false]", [&player](const std::vector<std::string>& params) { setPauseOnStartCommand(player, params); }));
     commands.emplace("setplaybackrate", Command("setplaybackrate", "Set playback rate. Usage: setplaybackrate <rate>", [&player](const std::vector<std::string>& params) { setPlayBackRateCommand(player, params); }));
     commands.emplace("setaudiovolume", Command("setaudiovolume", "Set audio volume. Usage: setaudiovolume <volume>", [&player](const std::vector<std::string>& params) { setAudioVolumeCommand(player, params); }));

--- a/test/pi-cli/commandProcessing.cpp
+++ b/test/pi-cli/commandProcessing.cpp
@@ -184,7 +184,7 @@ void initializeSourceForPlayerCommand(InterfacePlayerRDK& player, const std::vec
 
 void configurePipelineCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params) {
     // The signature from InterfacePlayerRDK.h:
-    // void ConfigurePipeline(int, int, int, int, bool, bool, bool, bool, int32_t, gint, const char *, int, bool, std::string url);
+    
     if (params.size() != 12) {
         std::cout << "Usage: configurepipeline <int> <int> <int> <bool> <bool> <bool> <int32> <gint> <pipelineName> <int> <bool> <url>\n";
         return;
@@ -193,19 +193,17 @@ void configurePipelineCommand(InterfacePlayerRDK& player, const std::vector<std:
     try {
         int format = std::stoi(params[0]);
         int audioFormat = std::stoi(params[1]);
-        int auxFormat = std::stoi(params[2]);
-        int subFormat = std::stoi(params[3]);
-        bool bESChangeStatus = (params[4] == "1" || params[4] == "true");
-        bool forwardAudioToAux = (params[5] == "1" || params[5] == "true");
-        bool setReadyAfterPipelineCreation = (params[6] == "1" || params[6] == "true");
-        bool isSubEnable = (params[7] == "1" || params[7] == "true");
-        int32_t trackId = std::stoi(params[8]);
-        gint rate = std::stoi(params[9]);
-        std::string pipelineNameStr = params[10];
+        int subFormat = std::stoi(params[2]);
+        bool bESChangeStatus = (params[3] == "1" || params[3] == "true");
+        bool setReadyAfterPipelineCreation = (params[4] == "1" || params[4] == "true");
+        bool isSubEnable = (params[5] == "1" || params[5] == "true");
+        int32_t trackId = std::stoi(params[6]);
+        gint rate = std::stoi(params[7]);
+        std::string pipelineNameStr = params[8];
         const char* pipelineName = pipelineNameStr.c_str();
-        int PipelinePriority = std::stoi(params[11]);
-        bool subBool = (params[12] == "1" || params[12] == "true");
-        std::string url = params[13];
+        int PipelinePriority = std::stoi(params[9]);
+        bool subBool = (params[10] == "1" || params[10] == "true");
+        std::string url = params[11];
 
         player.ConfigurePipeline(
             format, audioFormat, subFormat,

--- a/test/pi-cli/commandProcessing.cpp
+++ b/test/pi-cli/commandProcessing.cpp
@@ -208,8 +208,8 @@ void configurePipelineCommand(InterfacePlayerRDK& player, const std::vector<std:
         std::string url = params[13];
 
         player.ConfigurePipeline(
-            format, audioFormat, auxFormat, subFormat,
-            bESChangeStatus, forwardAudioToAux, setReadyAfterPipelineCreation, isSubEnable,
+            format, audioFormat, subFormat,
+            bESChangeStatus, setReadyAfterPipelineCreation, isSubEnable,
             trackId, rate, pipelineName, PipelinePriority, subBool, url
         );
         std::cout << "ConfigurePipeline executed.\n";
@@ -277,6 +277,19 @@ void pauseCommand(InterfacePlayerRDK& player, const std::vector<std::string>& pa
     }
     bool result = player.Pause(pauseVal, forceStop);
     std::cout << "Pause executed. Result: " << (result ? "true" : "false") << "\n";
+}
+
+void resumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params) {
+    if (!params.empty()) {
+        std::cout << "Usage: resume\n";
+        return;
+    }
+    bool result = player.Pause(false, false);
+    std::cout << "Resume executed. Success: " << (result ? "true" : "false") << "\n";
+    if (result) {
+        std::cout << "Pipeline state: " << (player.IsPipelinePaused() ? "Paused" : "Playing") << "\n";
+        std::cout << "Current position: " << player.GetPositionMilliseconds() << " ms\n";
+    }
 }
 
 void resumeInjectorCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params) {
@@ -601,6 +614,7 @@ std::map<std::string, Command> initializeCommands(CommandExecutor& executor, Int
     commands.emplace("setaudiovolume", Command("setaudiovolume", "Set audio volume. Usage: setaudiovolume <volume>", [&player](const std::vector<std::string>& params) { setAudioVolumeCommand(player, params); }));
     commands.emplace("setupstream", Command("setupstream", "Setup stream. Usage: setupstream <streamId> <playerInstance(int)> <url>", [&player](const std::vector<std::string>& params) { setupStreamCommand(player, params); }));
     commands.emplace("pause", Command("pause", "Pause the pipeline. Usage: pause [pause(bool)] [forceStop(bool)]", [&player](const std::vector<std::string>& params) { pauseCommand(player, params); }));
+    commands.emplace("resume", Command("resume", "Resume playback.\nUsage: resume", [&player](const std::vector<std::string>& params) { resumeCommand(player, params); }));
     commands.emplace("resumeinjector", Command("resumeinjector", "Resume injector.", [&player](const std::vector<std::string>& params) { resumeInjectorCommand(player, params); }));
     commands.emplace("stop", Command("stop", "Stop playback.", [&player](const std::vector<std::string>& params) { stopCommand(player, params); }));
     commands.emplace("flush", Command("flush", "Flush pipeline.", [&player](const std::vector<std::string>& params) { flushCommand(player, params); }));

--- a/test/pi-cli/commandProcessing.h
+++ b/test/pi-cli/commandProcessing.h
@@ -50,6 +50,7 @@ void setPlayBackRateCommand(InterfacePlayerRDK& player, const std::vector<std::s
 void setAudioVolumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void setupStreamCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void pauseCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
+void resumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params)
 void resumeInjectorCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void stopCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void flushCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);

--- a/test/pi-cli/commandProcessing.h
+++ b/test/pi-cli/commandProcessing.h
@@ -50,7 +50,7 @@ void setPlayBackRateCommand(InterfacePlayerRDK& player, const std::vector<std::s
 void setAudioVolumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void setupStreamCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void pauseCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
-void resumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params)
+void resumeCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void resumeInjectorCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void stopCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);
 void flushCommand(InterfacePlayerRDK& player, const std::vector<std::string>& params);


### PR DESCRIPTION
Reason for change : PI-CLI build process was failing due to auxFormat & forwardAudioToAux removed from ConfigurePipeline of PlayerInterface
Test procedure: Run L2-tests-player-interface.yml with act command and check tests are executed and report posted in the Comment section of Player Interface's recent PR
Risks: Low
Signed-off-by: Siddhesh siddhesh_chavan@comcast.com