### PR TITLE
RDKEMW-12785-2: Fix critical and high priority Coverity issues

### DIFF
--- a/drm/HlsDrmSessionManager.h
+++ b/drm/HlsDrmSessionManager.h
@@ -35,7 +35,7 @@
 
 class HlsDrmSessionManager : public PlayerHlsDrmSessionInterfaceBase
 {
-	DrmSession* mDrmSession;
+	DrmSession* mDrmSession = nullptr;
 public:
 	/**
 	 * @fn getInstance 

--- a/drm/HlsOcdmBridge.cpp
+++ b/drm/HlsOcdmBridge.cpp
@@ -100,3 +100,12 @@ void HlsOcdmBridge::CancelKeyWait(void)
 	//TBD:Unimplemented
 }
 
+/**
+ * @brief GetState Function to get current DRM State
+ */
+DRMState HlsOcdmBridge::GetState()
+{
+	std::lock_guard<std::mutex> guard(m_Mutex);
+	return m_drmState;
+}
+

--- a/drm/HlsOcdmBridge.h
+++ b/drm/HlsOcdmBridge.h
@@ -64,7 +64,7 @@ public:
 
 	virtual void AcquireKey(void *metadata,int trackType) override {};
 
-	virtual DRMState GetState() override {return m_drmState;}
+	virtual DRMState GetState() override;
 
 };
 


### PR DESCRIPTION
Reason for change : Added coverity changes for
drm/HlsDrmSessionManager.h, drm/HlsOcdmBridge.cpp, drm/HlsOcdmBridge.h 
Test procedure: As mentioned in ticket
Risks: Low