### PR TITLE
RDKEMW-12785-4: Fix critical and high priority Coverity issues

### DIFF
--- a/externals/contentsecuritymanager/ContentSecurityManagerSession.h
+++ b/externals/contentsecuritymanager/ContentSecurityManagerSession.h
@@ -92,17 +92,19 @@ public:
 	//allow copying, the secManager session will only be closed when all copies have gone out of scope
 	ContentSecurityManagerSession(const ContentSecurityManagerSession& other): mpSessionManager(), sessionIdMutex()
 	{
-		std::lock(sessionIdMutex, other.sessionIdMutex);
-		std::lock_guard<std::mutex> thisLock(sessionIdMutex, std::adopt_lock);
-		std::lock_guard<std::mutex> otherLock(other.sessionIdMutex, std::adopt_lock);
-		mpSessionManager=other.mpSessionManager;
+		std::unique_lock<std::mutex> thisLock(sessionIdMutex, std::defer_lock);
+		std::unique_lock<std::mutex> otherLock(other.sessionIdMutex, std::defer_lock);
+		std::lock(thisLock, otherLock);
+		mpSessionManager = other.mpSessionManager;
 	}
 	ContentSecurityManagerSession& operator=(const ContentSecurityManagerSession& other)
 	{
-		std::lock(sessionIdMutex, other.sessionIdMutex);
-		std::lock_guard<std::mutex> thisLock(sessionIdMutex, std::adopt_lock);
-		std::lock_guard<std::mutex> otherLock(other.sessionIdMutex, std::adopt_lock);
-		mpSessionManager=other.mpSessionManager;
+		if (this == &other)
+                    return *this;
+		std::unique_lock<std::mutex> thisLock(sessionIdMutex, std::defer_lock);
+		std::unique_lock<std::mutex> otherLock(other.sessionIdMutex, std::defer_lock);
+		std::lock(thisLock, otherLock);
+		mpSessionManager = other.mpSessionManager;
 		return *this;
 	}
 

--- a/externals/contentsecuritymanager/PlayerMemoryUtils.cpp
+++ b/externals/contentsecuritymanager/PlayerMemoryUtils.cpp
@@ -27,7 +27,8 @@
 #include <assert.h>
 #include <glib.h>
 #include <errno.h>
-
+#include <fcntl.h>
+#include <unistd.h>
 /**
  * @brief Creates shared memory and provides the key
  */
@@ -38,8 +39,30 @@ void * player_CreateSharedMem( size_t shmLen, key_t & shmKey)
 	{
 		for( int retryCount=0; retryCount<SHMGET_RETRY_MAX; retryCount++ )
 		{
-			// generate pseudo-random value to use as a unique key
-			shmKey = rand() + 1; // must be non-zero to allow access to non-child processes
+			// generate cryptographically secure random value to use as a unique key
+			int fd = open("/dev/urandom", O_RDONLY);
+			if( fd != -1 )
+			{
+				ssize_t bytesRead = read(fd, &shmKey, sizeof(key_t));
+                close(fd);
+    			if( bytesRead != sizeof(key_t) )
+				{
+    					MW_LOG_ERR("Failed to read full key from /dev/urandom, bytesRead=%zd", bytesRead);
+    					continue;
+				}
+
+				if( shmKey == 0 )
+				{
+    					MW_LOG_WARN("Generated zero shared memory key from /dev/urandom, retrying");
+    					continue;
+				}	
+			}
+			else
+			{
+				MW_LOG_ERR("Failed to open /dev/urandom: %d", errno);
+				continue;
+			}
+			
 
 			// allocate memory segment and identifier
 			int shmId = shmget(shmKey, shmLen,

--- a/externals/contentsecuritymanager/SecManagerThunder.cpp
+++ b/externals/contentsecuritymanager/SecManagerThunder.cpp
@@ -245,23 +245,27 @@ bool SecManagerThunder::AcquireLicenseOpenOrUpdate( std::string clientId, std::s
 
 							if (licenseDecoded != nullptr && licenseDecodedLen != 0)
 							{
-								MW_LOG_INFO("SecManager license post base64 decode length: %d", *licenseResponseLength);
 								*licenseResponse = (char*) malloc(licenseDecodedLen);
 								if (*licenseResponse)
 								{
 									memcpy(*licenseResponse, licenseDecoded, licenseDecodedLen);
 									*licenseResponseLength = licenseDecodedLen;
+								        MW_LOG_INFO("SecManager license post base64 decode length: %d", *licenseResponseLength);
+									ret = true;
 								}
 								else
 								{
 									MW_LOG_ERR("SecManager failed to allocate memory for license!");
 								}
-								free(licenseDecoded);
-								ret = true;
 							}
 							else
 							{
 								MW_LOG_ERR("SecManager license base64 decode failed!");
+							}
+							
+							if (licenseDecoded != nullptr)
+							{
+								free(licenseDecoded);
 							}
 						}
 					}


### PR DESCRIPTION
Reason for change : Added coverity changes for
externals/contentsecuritymanager/ContentSecurityManagerSession.h, externals/contentsecuritymanager/PlayerMemoryUtils.cpp, externals/contentsecuritymanager/SecManagerThunder.cpp 
Test procedure: As mentioned in ticket
Risks: Low