### PR TITLE
Fix LOCK in PlayerScheduler.cpp

### DIFF
--- a/PlayerScheduler.cpp
+++ b/PlayerScheduler.cpp
@@ -186,10 +186,13 @@ void PlayerScheduler::StopScheduler()
 	RemoveAllTasks();
 
 	//prevent possible deadlock where mSchedulerThread is waiting for mExLock/mExMutex
-	ResumeScheduler();
+	if(mLockOut)
+	{
+		ResumeScheduler();
+	}
 	mQCond.notify_one();
-    if (mSchedulerThread.joinable())
-        mSchedulerThread.join();
+        if (mSchedulerThread.joinable())
+            mSchedulerThread.join();
 }
 
 /**


### PR DESCRIPTION
## Automated Fix for LOCK

**File:** `/PlayerScheduler.cpp`
**Line:** 47

### Defect Details
Double unlock

### Fix Applied
This automated fix addresses the LOCK defect by:
The fix correctly addresses the double-unlock Coverity defect by guarding the ResumeScheduler() call with 'if(mLockOut)', ensuring mExLock.unlock() is only called when the lock was actually acquired. The mLockOut flag accurately tracks the lock state (set true by SuspendScheduler, false by ResumeScheduler), making this a correct and minimal fix. A minor unrelated indentation change was introduced but does not affect correctness or logic.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
