### PR TITLE
Fix MISSING_LOCK in PlayerScheduler.cpp

### DIFF
--- a/PlayerScheduler.cpp
+++ b/PlayerScheduler.cpp
@@ -178,7 +178,12 @@ void PlayerScheduler::StopScheduler()
 
 	//allow StopScheduler() to be called without warning from a nonsuspended state and
 	//not cause an error in ResumeScheduler() below due to trying to unlock an unlocked lock
-	if(!mLockOut)
+	bool lockOut;
+	{
+		std::lock_guard<std::mutex>lock(mQMutex);
+		lockOut = mLockOut;
+	}
+	if(!lockOut)
 	{
 		SuspendScheduler();
 	}
@@ -188,8 +193,8 @@ void PlayerScheduler::StopScheduler()
 	//prevent possible deadlock where mSchedulerThread is waiting for mExLock/mExMutex
 	ResumeScheduler();
 	mQCond.notify_one();
-    if (mSchedulerThread.joinable())
-        mSchedulerThread.join();
+        if (mSchedulerThread.joinable())
+            mSchedulerThread.join();
 }
 
 /**
@@ -218,6 +223,7 @@ void PlayerScheduler::ResumeScheduler()
 bool PlayerScheduler::RemoveTask(int id)
 {
 	bool ret = false;
+	std::lock_guard<std::mutex>exLock(mExMutex);
 	std::lock_guard<std::mutex>lock(mQMutex);
 	// Make sure its not currently executing/executed task
 	if (id != PLAYER_TASK_ID_INVALID && mCurrentTaskId != id)


### PR DESCRIPTION
## Automated Fix for MISSING_LOCK

**File:** `/PlayerScheduler.cpp`
**Line:** 223

### Defect Details
Data race condition

### Fix Applied
This automated fix addresses the MISSING_LOCK defect by:
The fix correctly addresses the MISSING_LOCK defect in two places: (1) reading mLockOut in StopScheduler() is now protected by mQMutex, using a local copy to avoid holding the lock during SuspendScheduler(); (2) RemoveTask() now acquires mExMutex before mQMutex, protecting the read of mCurrentTaskId which is written under mExMutex in ExecuteAsyncTask(). Lock ordering is consistent with existing code. One minor unrelated indentation change was introduced but does not affect correctness or logic.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
