### PR TITLE
Fix PW.USELESS_TYPE_QUALIFIER_ON_RETURN_TYPE in SubtecPacket.hpp

### DIFF
--- a/subtec/libsubtec/SubtecPacket.hpp
+++ b/subtec/libsubtec/SubtecPacket.hpp
@@ -34,7 +34,7 @@ public:
     Packet() : m_buffer(), m_counter(std::numeric_limits<std::uint32_t>::max()) {}
     Packet(std::uint32_t counter) : m_buffer(), m_counter(counter) {}
 
-    const uint32_t getType()
+    uint32_t getType()
     {
         uint32_t type = 0;
 
@@ -54,7 +54,7 @@ public:
         return m_buffer;
     }
     
-    const std::uint32_t getCounter()
+    std::uint32_t getCounter()
     {
         return m_counter;
     }


### PR DESCRIPTION
## Automated Fix for PW.USELESS_TYPE_QUALIFIER_ON_RETURN_TYPE

**File:** `/subtec/libsubtec/SubtecPacket.hpp`
**Line:** None

### Defect Details
Parse warning

### Fix Applied
This automated fix addresses the PW.USELESS_TYPE_QUALIFIER_ON_RETURN_TYPE defect by:
Patch correctly and minimally removes useless 'const' qualifiers from value-returning functions getType() and getCounter(). The fix addresses the static analysis warning without introducing functional changes or new defects.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
