### PR TITLE
RDKEMW-18116: Aligned player interface component with Aamp RDK-61151_federated_2604

### DIFF
--- a/InterfacePlayerPriv.h
+++ b/InterfacePlayerPriv.h
@@ -212,7 +212,6 @@ struct GstPlayerPriv
 	int numberOfVideoBuffersSent;                                                    /**< Number of video buffers sent to pipeline */
 	gint64 segmentStart;                                                                     /**< segment start value; required when qtdemux is enabled or restamping is disabled; -1 to send a segment.start query to gstreamer */
 	GstQuery *positionQuery;                                                                 /**< pointer that holds a position query object */
-	GstQuery *durationQuery;                                                                 /**< pointer that holds a duration query object */
 	bool paused;                                                                                     /**< if pipeline is deliberately put in PAUSED state due to user interaction */
 	GstState pipelineState;                                                                  /**< current state of pipeline */
 	GstTaskControlData firstVideoFrameDisplayedCallbackTask; /**< Task control data of the handler created for notifying state changed to Playing */
@@ -262,7 +261,7 @@ class InterfacePlayerPriv
 	private:
 	protected:
 	public:
-		InterfacePlayerPriv();
+		InterfacePlayerPriv(bool isRialto);
 		~InterfacePlayerPriv();
 		GstPlayerPriv *gstPrivateContext;
 		std::shared_ptr<SocInterface> socInterface;

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -87,11 +87,12 @@ const char * CipherTypeToString(CipherType type)
 }
 
 /*InterfacePlayerRDK constructor*/
-InterfacePlayerRDK::InterfacePlayerRDK() :
+InterfacePlayerRDK::InterfacePlayerRDK(bool isRialto) :
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
 mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL), mDRMSessionManager(NULL)
 {
-	interfacePlayerPriv = new InterfacePlayerPriv();
+	interfacePlayerPriv = new InterfacePlayerPriv(isRialto);
+	MW_LOG_MIL("InterfacePlayerRDK constructed using external library");
 	m_gstConfigParam = new Configs();
 	m_gstConfigParam->framesToQueue = SocUtils::RequiredQueuedFrames();
 	pthread_mutex_init(&mProtectionLock, NULL);
@@ -120,10 +121,11 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	delete interfacePlayerPriv;
 }
 
-InterfacePlayerPriv::InterfacePlayerPriv():mPlayerName()
+InterfacePlayerPriv::InterfacePlayerPriv(bool isRialto):mPlayerName()
 {
 	gstPrivateContext = new GstPlayerPriv();
-	socInterface = SocInterface::CreateSocInterface();
+	socInterface = SocInterface::CreateSocInterface(isRialto);
+
 }
 
 InterfacePlayerPriv::~InterfacePlayerPriv()
@@ -146,7 +148,7 @@ using_westerossink(false), usingRialtoSink(false), usingClosedCaptionsControl(fa
 buffering_enabled(FALSE), buffering_in_progress(FALSE), buffering_timeout_cnt(0),
 buffering_target_state(GST_STATE_NULL),
 lastKnownPTS(0), ptsUpdatedTimeMS(0), ptsCheckForEosOnUnderflowIdleTaskId(GST_TASK_ID_INVALID),
-numberOfVideoBuffersSent(0), segmentStart(0), positionQuery(NULL), durationQuery(NULL),
+numberOfVideoBuffersSent(0), segmentStart(0), positionQuery(NULL),
 paused(false), pipelineState(GST_STATE_NULL),
 firstVideoFrameDisplayedCallbackTask("FirstVideoFrameDisplayedCallback"),
 firstTuneWithWesterosSinkOff(false),
@@ -187,7 +189,6 @@ GstPlayerPriv::~GstPlayerPriv()
 		g_clear_object(&protectionEvent[i]);
 	}
 	g_clear_object(&positionQuery);
-	g_clear_object(&durationQuery);
 }
 
 /**
@@ -1821,7 +1822,6 @@ void InterfacePlayerRDK::InitializeSourceForPlayer(void *PlayerInstance, void * 
 		int MaxGstVideoBufBytes = m_gstConfigParam->videoBufBytes;
 		MW_LOG_INFO("Setting gst Video buffer max bytes to %d", MaxGstVideoBufBytes);
 		g_object_set(source, "max-bytes", (guint64)MaxGstVideoBufBytes, NULL);			/* Sets the maximum video buffer bytes as per configuration*/
-		
 		if( privatePlayer->gstPrivateContext->usingRialtoSink &&
 		   !privatePlayer->socInterface->IsVideoMaster(privatePlayer->gstPrivateContext->video_sink) )
 		{
@@ -2745,27 +2745,28 @@ long long InterfacePlayerRDK::GetPositionMilliseconds(void)
 long InterfacePlayerRDK::GetDurationMilliseconds(void)
 {
 	long rc = 0;
+	GstQuery *durationQuery = NULL;
 	if( interfacePlayerPriv->gstPrivateContext->pipeline )
 	{
 		if( interfacePlayerPriv->gstPrivateContext->pipelineState == GST_STATE_PLAYING || // playing
 		   (interfacePlayerPriv->gstPrivateContext->pipelineState == GST_STATE_PAUSED && interfacePlayerPriv->gstPrivateContext->paused) ) // paused by user
 		{
-			interfacePlayerPriv->gstPrivateContext->durationQuery = gst_query_new_duration(GST_FORMAT_TIME);	/*Constructs a new stream duration query object to query in the given format */
-			if( interfacePlayerPriv->gstPrivateContext->durationQuery )
+			durationQuery = gst_query_new_duration(GST_FORMAT_TIME);	/*Constructs a new stream duration query object to query in the given format */
+			if( durationQuery )
 			{
-				gboolean res = gst_element_query(interfacePlayerPriv->gstPrivateContext->pipeline,interfacePlayerPriv->gstPrivateContext->durationQuery);
+				gboolean res = gst_element_query(interfacePlayerPriv->gstPrivateContext->pipeline,durationQuery);
 				if( res )
 				{
 					gint64 duration;
-					gst_query_parse_duration(interfacePlayerPriv->gstPrivateContext->durationQuery, NULL, &duration); /* parses the value into duration */
+					gst_query_parse_duration(durationQuery, NULL, &duration); /* parses the value into duration */
 					rc = GST_TIME_AS_MSECONDS(duration);
 				}
 				else
 				{
 					MW_LOG_ERR("Duration query failed");
 				}
-				gst_query_unref(interfacePlayerPriv->gstPrivateContext->durationQuery);		/* Decreases the refcount of the durationQuery. In this case the count will be zero, so it will be freed*/
-				interfacePlayerPriv->gstPrivateContext->durationQuery = NULL;
+				gst_query_unref(durationQuery);		/* Decreases the refcount of the durationQuery. In this case the count will be zero, so it will be freed*/
+				durationQuery = NULL;
 			}
 			else
 			{

--- a/InterfacePlayerRDK.h
+++ b/InterfacePlayerRDK.h
@@ -40,7 +40,6 @@
 
 // Forward declarations
 class InterfacePlayerPriv;
-class AampGrowableBuffer;
 
 struct MonitorAVState
 {
@@ -166,8 +165,8 @@ class InterfacePlayerRDK
 		std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
         
 		PlayerScheduler mScheduler;
-        	InterfacePlayerRDK();
-        	~InterfacePlayerRDK();
+		InterfacePlayerRDK(bool isRialto = false);
+		~InterfacePlayerRDK();
 		InterfacePlayerPriv* GetPrivatePlayer();
 		/**
 		 * @brief Clears the flags for an idle task.

--- a/test/utests/fakes/FakeSocInterface.cpp
+++ b/test/utests/fakes/FakeSocInterface.cpp
@@ -29,6 +29,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
         std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
         return obj;
 }
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+        std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
+        return obj;
+}
 bool DefaultSocInterface::UseAppSrc()
 {
 #if defined (__APPLE__)

--- a/vendor/SocInterface.cpp
+++ b/vendor/SocInterface.cpp
@@ -28,6 +28,8 @@
 #endif
 
 
+/**Initially re-sets the IsRialtoMode */
+bool SocInterface::mIsRialtoMode = false;
 /**
  * @brief Checks if the input string starts with the given prefix.
  *
@@ -154,6 +156,21 @@ SocPlatformType SocInterface::InferPlatformFromDeviceProperties( void )
 
 
 /**
+ * @brief Loads the instance with rialto mode or not 
+ *
+ * @return A pointer to the created SocInterface object, or nullptr on failure.
+ */
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+	if(isRialto == true)
+	{
+	    MW_LOG_MIL("Rialto is enabled and creating default soc");
+	}
+	mIsRialtoMode = isRialto;
+	return CreateSocInterface();
+}
+
+/**
  * @brief Creates an instance of the SoC-specific interface based on the detected platform.
  *
  * @return A pointer to the created SocInterface object, or nullptr on failure.
@@ -166,7 +183,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
 		SocPlatformType platformType = InferPlatformFromDeviceProperties();
 		if(platformType == SOC_PLATFORM_DEFAULT)
 		{
-			platformType = InferPlatformFromPluginScan();
+			if(!mIsRialtoMode)
+			{
+				MW_LOG_MIL("Performing InterfacePluginScan| Rialto-Enabled");
+				platformType = InferPlatformFromPluginScan();
+            }
 		}
 #if !defined(__APPLE__) && !defined(UBUNTU)
 		switch (platformType)

--- a/vendor/SocInterface.h
+++ b/vendor/SocInterface.h
@@ -28,7 +28,7 @@
 #include <gst/base/gstbasetransform.h>
 #include "PlayerLogManager.h"
 
-#define REQUIRED_QUEUED_FRAMES_DEFAULT (5+1)
+#define REQUIRED_QUEUED_FRAMES_DEFAULT 4 // reduced from 6 to 4 to satisfy least common denominator
 
 typedef gboolean (*AcceptCapsFunc)(GstBaseTransform *, GstPadDirection, GstCaps *);
 
@@ -94,6 +94,11 @@ protected:
 public:
 	SocInterface() {}
 
+	/** 
+	 * @brief Set rialto mode or not
+	 * @return True when rialto is enabled 
+	 */
+	static bool mIsRialtoMode;
 	/**
 	 * @brief Sets the state of Westeros Sink usage.
 	 *
@@ -140,6 +145,11 @@ public:
 	 * @return A pointer to the created SocInterface object.
 	 */
 	static std::shared_ptr<SocInterface> CreateSocInterface();
+	/**
+	 * @brief Creates an instance of the SoC-specific interface with argument as rialtomode or not .
+	 * @return A pointer to the created SocInterface object.
+	 */
+	static std::shared_ptr<SocInterface> CreateSocInterface(bool isRialto);
 
 	/**
 	 * @brief Configure the accept caps
@@ -291,7 +301,7 @@ public:
 	 * @return True on success, false otherwise.
 	 */
 	virtual bool SetRateCorrection() = 0;
-	
+
 	/**
 	 * @brief Check if the given name is a video sink.
 	 * @param name Element name.

--- a/vendor/mtk/MtkSocInterface.cpp
+++ b/vendor/mtk/MtkSocInterface.cpp
@@ -20,7 +20,7 @@
 #include "MtkSocInterface.h"
 
 /**
- @brief this interface implementation used with Rialto
+ @brief this interface implementation used with Mtk SoC platforms
  */
 MtkSocInterface::MtkSocInterface()
 {
@@ -35,9 +35,6 @@ MtkSocInterface::MtkSocInterface()
  */
 bool MtkSocInterface::UseAppSrc()
 {
-#if defined (__APPLE__)
-	return true;
-#endif
 	return false;
 }
 
@@ -50,9 +47,6 @@ void MtkSocInterface::SetAudioProperty(const char * &volume, const char * &mute,
 	isSinkBinVolume = false;
 	volume = "volume";
 	mute = "mute";
-#if defined(__APPLE__)
-	isSinkBinVolume = true;
-#endif
 }
 
 /**
@@ -68,9 +62,7 @@ void MtkSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 
 bool MtkSocInterface::IsVideoSink(const char* name)
 {
-	return name && (
-					StartsWith(name,"rialtomsevideosink") ||
-					StartsWith(name, "westerossink") );
+	return name && StartsWith(name, "westerossink");
 }
 
 /**
@@ -80,9 +72,7 @@ bool MtkSocInterface::IsVideoSink(const char* name)
  */
 bool MtkSocInterface::IsVideoDecoder(const char* name)
 {
-	return name && (
-					StartsWith(name,"rialtomsevideosink") ||
-					StartsWith(name, "westerossink") );
+	return name && StartsWith(name, "westerossink");
 }
 
 /**
@@ -96,10 +86,6 @@ bool MtkSocInterface::IsAudioOrVideoDecoder(const char* name)
 
 	// ignore audio/video decoder check if westeros sink disabled via config, UseWesterosSink()
     if(UseWesterosSink() && StartsWith(name, "westerossink"))
-    {
-        AudioOrVideoDecoder = true;
-    }
-    else if(StartsWith(name, "rialtomse"))
     {
         AudioOrVideoDecoder = true;
     }
@@ -117,12 +103,7 @@ bool MtkSocInterface::IsAudioOrVideoDecoder(const char* name)
  */
 void MtkSocInterface::SetPlaybackFlags(gint &flags, bool isSub)
 {
-#if defined(__APPLE__)
-	// on OSX, just use working defaults
-	// note that if PLAY_FLAG_DEINTERLACE is not included, video freezes on first frame
-#else
 	flags = PLAY_FLAG_VIDEO | PLAY_FLAG_AUDIO | PLAY_FLAG_SOFT_VOLUME;
-#endif
 	if(isSub)
 	{
 		flags = PLAY_FLAG_TEXT;
@@ -136,61 +117,30 @@ bool MtkSocInterface::IsSimulatorFirstFrame()
 
 bool MtkSocInterface::IsSimulatorSink()
 {
-#if !defined(UBUNTU)
-	return false;
-#endif
 	return true;
 }
 
 void MtkSocInterface::ConfigurePluginPriority()
 {
-#ifdef UBUNTU
-	GstPluginFeature* pluginFeature = gst_registry_lookup_feature(gst_registry_get(), "pulsesink");
-	if (pluginFeature != NULL)
-	{
-		MW_LOG_INFO("InterfacePlayerRDK: pulsesink plugin priority set to GST_RANK_SECONDARY");
-		gst_plugin_feature_set_rank(pluginFeature, GST_RANK_SECONDARY);
-		gst_object_unref(pluginFeature);
-	}
-#endif
+
 }
 
 bool MtkSocInterface::ShouldTearDownForTrickplay()
 {
-#if defined(__APPLE__) || defined(UBUNTU)
-	return true;
-#endif
 	return false;
 }
 
 bool MtkSocInterface::IsSimulatorVideoSample()
 {
-#if defined(__APPLE__)
-	return true;
-#endif
 	return true;
 }
 
 void MtkSocInterface::SetH264Caps(GstCaps *caps)
 {
-#ifdef UBUNTU
-	// below required on Ubuntu - harmless on OSX, but breaks RPI
-	gst_caps_set_simple (caps,
-			"alignment", G_TYPE_STRING, "au",
-			"stream-format", G_TYPE_STRING, "avc",
-			NULL);
-#endif
 }
 
 void MtkSocInterface::SetHevcCaps(GstCaps *caps)
 {
-#ifdef UBUNTU
-	// below required on Ubuntu - harmless on OSX, but breaks RPI
-	gst_caps_set_simple(caps,
-			"alignment", G_TYPE_STRING, "au",
-			"stream-format", G_TYPE_STRING, "hev1",
-			NULL);
-#endif
 }
 
 /**
@@ -202,14 +152,7 @@ void MtkSocInterface::SetHevcCaps(GstCaps *caps)
  */
 bool MtkSocInterface::ConfigureAudioSink(GstElement **audio_sink, GstObject *src, bool decStreamSync)
 {
-        bool status = false;
-        if (StartsWith(GST_OBJECT_NAME(src), "amlhalasink") == true)
-        {
-                gst_object_replace((GstObject **)audio_sink, src);
-                g_object_set(audio_sink, "disable-xrun", TRUE, NULL);
-                status = true;
-        }
-        return status;
+    return false;
 }
 
 /**
@@ -224,50 +167,40 @@ bool MtkSocInterface::ConfigureAudioSink(GstElement **audio_sink, GstObject *src
  */
 bool MtkSocInterface::SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec)
 {
-	#if defined(__APPLE__) || defined(UBUNTU)
+	//For rialto sinks default soc routine will be called
+	if(!pipeline)
+	{
+		MW_LOG_ERR("Failed to set playback rate");
 		return false;
-    #else
-		if(!pipeline)
-		{
-			MW_LOG_ERR("Failed to set playback rate");
-			return false;
-		}
-		MW_LOG_MIL("=send custom-instant-rate-change : %f ...", rate);
-		GstStructure *structure = gst_structure_new("custom-instant-rate-change", "rate", G_TYPE_DOUBLE, rate, NULL);
-		if(!structure)
-		{
-			MW_LOG_ERR("Failed to create custom-instant-rate-change structure");
-			return false;
-		}
-		/* The above statement creates a new GstStructure with the name
-		   'custom-instant-rate-change' that has a member variable
-		   'rate' of G_TYPE_DOUBLE and a value of rate i.e. second last parameter */
-		GstEvent * rate_event = gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, structure);
-		if (!rate_event)
-		{
-			MW_LOG_ERR("Failed to create rate_event");
-			gst_structure_free (structure);
-			return false;
-		}
-		int ret = gst_element_send_event(pipeline, rate_event );
-		if(!ret)
-		{
-			MW_LOG_ERR("Rate change failed : %g [gst_element_send_event]", rate);
-			return false;
-		}
-		MW_LOG_MIL("Current rate: %g", rate);
-		return true;
-	#endif
+	}
+	MW_LOG_MIL("=send custom-instant-rate-change : %f ...", rate);
+	GstStructure *structure = gst_structure_new("custom-instant-rate-change", "rate", G_TYPE_DOUBLE, rate, NULL);
+	if(!structure)
+	{
+		MW_LOG_ERR("Failed to create custom-instant-rate-change structure");
+		return false;
+	}
+	/* The above statement creates a new GstStructure with the name
+		'custom-instant-rate-change' that has a member variable
+		'rate' of G_TYPE_DOUBLE and a value of rate i.e. second last parameter */
+	GstEvent * rate_event = gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_OOB, structure);
+	if (!rate_event)
+	{
+		MW_LOG_ERR("Failed to create rate_event");
+		gst_structure_free (structure);
+		return false;
+	}
+	int ret = gst_element_send_event(pipeline, rate_event );
+	if(!ret)
+	{
+		MW_LOG_ERR("Rate change failed : %g [gst_element_send_event]", rate);
+		return false;
+	}
+	MW_LOG_MIL("Current rate: %g", rate);
+	return true;
 }
 
 bool MtkSocInterface::IsVideoMaster(GstElement *videoSink)
 {
-	gboolean isMaster{TRUE};
-	GParamSpec *pspec = g_object_class_find_property(G_OBJECT_GET_CLASS(videoSink),"is-master");
-	if( pspec!=NULL )
-	{ // rialto-specific
-		g_object_get(videoSink, "is-master", &isMaster, nullptr);
-		MW_LOG_INFO("is-master %d", isMaster);
-	}
-	return (isMaster == TRUE);
+	return true;
 }


### PR DESCRIPTION
RDEMW-18116: Aligned player interface component with Aamp's RDK-61151_federated_2604
Reason for change: Aligning middleware-interface component with respect to Aamp's RDK-61151_federated_2604
Test Procedure: No regression in aamp's playback 
Risks: Medium

Signed-off-by: deepikasri_n@comcast.com <deepikasri_n@comcast.com>
