### PR TITLE
RDKEMW-17599: Fix Low priority Coverity issues

### DIFF
--- a/closedcaptions/subtec/CCDataController.cpp
+++ b/closedcaptions/subtec/CCDataController.cpp
@@ -274,7 +274,7 @@ namespace
     }
 }
 
-void CCDataController::sendCCSetAttribute(gsw_CcAttributes * attrib, short type, gsw_CcType ccType)
+void CCDataController::sendCCSetAttribute(gsw_CcAttributes * attrib, uint32_t type, gsw_CcType ccType)
 {
     using AttributesArray = std::array<uint32_t, 14> ;
 
@@ -312,7 +312,7 @@ void CCDataController::sendCCSetAttribute(gsw_CcAttributes * attrib, short type,
 
     const auto ccTypeValue = getValue(ccType);
 
-    channel.SendCCSetAttributePacket(ccTypeValue, uint32_t{type}, attributes);
+    channel.SendCCSetAttributePacket(ccTypeValue, type, attributes);
 }
 
 void closedCaptionDecodeCb(void *context, int decoderIndex, int event)

--- a/closedcaptions/subtec/CCDataController.h
+++ b/closedcaptions/subtec/CCDataController.h
@@ -62,7 +62,7 @@ public:
     void sendPause();
     void sendResume();
     void sendResetChannelPacket();
-    void sendCCSetAttribute(gsw_CcAttributes * attrib, short type, gsw_CcType ccType);
+    void sendCCSetAttribute(gsw_CcAttributes * attrib, uint32_t type, gsw_CcType ccType);
 
     void ccSetDigitalChannel(unsigned int channel);
     void ccSetAnalogChannel(unsigned int channel);

--- a/closedcaptions/subtec/SubtecConnector.cpp
+++ b/closedcaptions/subtec/SubtecConnector.cpp
@@ -151,7 +151,8 @@ namespace ccMgrAPI
                 {
                     ((gsw_CcColor*)values[i])->rgb = pValues[i];
                     strncpy(((gsw_CcColor*)values[i])->name, pValuesNames[i],
-                            GSW_MAX_CC_COLOR_NAME_LENGTH);
+                            GSW_MAX_CC_COLOR_NAME_LENGTH - 1);
+                    ((gsw_CcColor*)values[i])->name[GSW_MAX_CC_COLOR_NAME_LENGTH - 1] = '\0';
                 }
                 break;
             }

--- a/drm/helper/DrmHelper.h
+++ b/drm/helper/DrmHelper.h
@@ -92,7 +92,7 @@ public:
 	const std::string EMPTY_DRM_METADATA;
 	
 	const std::string EMPTY_STRING;
-	DrmHelper(const struct DrmInfo drmInfo) : mDrmInfo(drmInfo), TIMEOUT_SECONDS(5000U), EMPTY_DRM_METADATA(), EMPTY_STRING() ,bOutputProtectionEnabled(false), protectionScheme() {}
+	DrmHelper(const struct DrmInfo& drmInfo) : mDrmInfo(drmInfo), TIMEOUT_SECONDS(5000U), EMPTY_DRM_METADATA(), EMPTY_STRING() ,bOutputProtectionEnabled(false), protectionScheme() {}
 	DrmHelper(const DrmHelper&) = delete;
 	DrmHelper& operator=(const DrmHelper&) = delete;
 	

--- a/subtec/libsubtec/SubtecPacket.hpp
+++ b/subtec/libsubtec/SubtecPacket.hpp
@@ -34,7 +34,7 @@ public:
     Packet() : m_buffer(), m_counter(std::numeric_limits<std::uint32_t>::max()) {}
     Packet(std::uint32_t counter) : m_buffer(), m_counter(counter) {}
 
-    const uint32_t getType()
+    uint32_t getType()
     {
         uint32_t type = 0;
 
@@ -54,7 +54,7 @@ public:
         return m_buffer;
     }
     
-    const std::uint32_t getCounter()
+    std::uint32_t getCounter()
     {
         return m_counter;
     }


### PR DESCRIPTION
Reason for change: Fixed BUFFER_SIZE, PASS_BY_VALUE, PW.NARROWING_CONVERSION, PW.USELESS_TYPE_QUALIFIER_ON_RETURN_TYPE
Test procedure: As mentioned in ticket
Risks: Low