### PR TITLE
RDKEMW-17597-2: Fix medium priority Coverity issues-UNUSED_VALUE,SLEEP

### DIFF
--- a/externals/contentsecuritymanager/IFirebolt/ContentProtectionFirebolt.cpp
+++ b/externals/contentsecuritymanager/IFirebolt/ContentProtectionFirebolt.cpp
@@ -244,7 +244,7 @@ bool ContentProtectionFirebolt::AcquireLicenseOpenOrUpdate( std::string clientId
 	}
 
 	{
-		std::lock_guard<std::mutex> lock(mContentProtectionMutex);
+		std::unique_lock<std::mutex> lock(mContentProtectionMutex);
 		if (!accessTokenStr.empty() &&
 				!contentMetaDataStr.empty() &&
 				!licenseRequestStr.empty())
@@ -406,7 +406,11 @@ bool ContentProtectionFirebolt::AcquireLicenseOpenOrUpdate( std::string clientId
 					{
 						++retryCount;
 						MW_LOG_WARN("ContentProtection license request failed, response for %s : statusCode: %d, reasonCode: %d, so retrying with delay %d, retry count : %u", apiName, *statusCode, *reasonCode, sleepTime, retryCount );
-						ms_sleep(sleepTime);						
+						// Release lock before sleeping to avoid blocking other threads
+						lock.unlock();
+						ms_sleep(sleepTime);
+						// Re-acquire lock for next iteration
+						lock.lock();
 					}
 					else
 					{

--- a/vendor/amlogic/AmlogicSocInterface.cpp
+++ b/vendor/amlogic/AmlogicSocInterface.cpp
@@ -246,7 +246,6 @@ bool AmlogicSocInterface::IsAudioOrVideoDecoder(const char* name)
  */
 void AmlogicSocInterface::SetPlaybackFlags(gint &flags, bool isSub)
 {
-	flags = PLAY_FLAG_VIDEO | PLAY_FLAG_AUDIO | PLAY_FLAG_NATIVE_AUDIO | PLAY_FLAG_NATIVE_VIDEO;
 	flags = PLAY_FLAG_VIDEO | PLAY_FLAG_AUDIO | PLAY_FLAG_SOFT_VOLUME;
 	if(isSub)
 	{

--- a/vendor/realtek/RealtekSocInterface.cpp
+++ b/vendor/realtek/RealtekSocInterface.cpp
@@ -277,8 +277,6 @@ void RealtekSocInterface::SetFreerunThreshold(GstObject* src)
  */
 void RealtekSocInterface::SetPlaybackFlags(gint &flags, bool isSub)
 {
-	flags = PLAY_FLAG_VIDEO | PLAY_FLAG_AUDIO | PLAY_FLAG_NATIVE_AUDIO | PLAY_FLAG_NATIVE_VIDEO;
-
 	flags = PLAY_FLAG_VIDEO | PLAY_FLAG_AUDIO |  PLAY_FLAG_NATIVE_AUDIO | PLAY_FLAG_NATIVE_VIDEO | PLAY_FLAG_SOFT_VOLUME;
 	if(isSub)
 	{


### PR DESCRIPTION
Reason for change: Removed deadcode, moved sleep out of lockscope and used const to avoid copy
Test procedure: As in ticket
Risks: Medium