### PR TITLE
RDKEMW-16544 : string based firebolt error logging

### DIFF
--- a/externals/PlayerExternalUtils.h
+++ b/externals/PlayerExternalUtils.h
@@ -30,9 +30,11 @@
 
 #define MW_PRE_LOGGER_LOG(fmt, ...)                                            \
     do {                                                                    \
-        std::printf("[MIDDLEWARE] %s:%d %s: " fmt, __FILE__, __LINE__,      \
-                    __func__ , ##__VA_ARGS__);                              \
-        std::fflush(stdout);                                                \
+        if (stderr != nullptr) {                                            \
+            std::fprintf(stderr, "[MIDDLEWARE] %s:%d %s: " fmt, __FILE__, __LINE__, \
+                         __func__ , ##__VA_ARGS__);                         \
+            std::fflush(stderr);                                            \
+        }                                                                   \
     } while (0)
 
 

--- a/externals/contentsecuritymanager/IFirebolt/ContentProtectionFirebolt.cpp
+++ b/externals/contentsecuritymanager/IFirebolt/ContentProtectionFirebolt.cpp
@@ -109,7 +109,10 @@ void ContentProtectionFirebolt::SubscribeEvents()
 	}
 	else
 	{
-		MW_LOG_ERR("Failed to subscribe to watermark events: %d", static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("Failed to subscribe to watermark events: %d Message: %s",
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 }
 
@@ -120,7 +123,10 @@ void ContentProtectionFirebolt::UnSubscribeEvents()
 		Firebolt::IFireboltAampAccessor::Instance().ContentProtectionInterface().unsubscribe(mSubscriptionId);
 	if (result.error() != Firebolt::Error::None)
 	{
-		MW_LOG_ERR("Failed to Unsubscribe to watermark events: %d", static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("Failed to Unsubscribe to watermark events: %d Message: %s",
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 }
 
@@ -446,7 +452,10 @@ void ContentProtectionFirebolt::CloseDrmSession(int64_t sessionId)
 	else
 	{
 		// An error occurred, log the error
-		MW_LOG_ERR("CloseDrmSession: failed for sessionID: %" PRId64 " Firebolt Error: \"%d\"", sessionId, static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("CloseDrmSession: failed for sessionID: %" PRId64 " Firebolt Error: \"%d\" Message: %s", sessionId,
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 }
 bool ContentProtectionFirebolt::SetDrmSessionState(int64_t sessionId, bool active)
@@ -481,7 +490,10 @@ bool ContentProtectionFirebolt::SetDrmSessionState(int64_t sessionId, bool activ
 	else
 	{
 		// An error occurred, log the error
-		MW_LOG_ERR("DRM session state failed to set to %d for sessionId: %" PRId64 ", Firebolt Error: \"%d\"", static_cast<int>(sessionState), sessionId, static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("DRM session state failed to set to %d for sessionId: %" PRId64 ", Firebolt Error: \"%d\" Message: %s", static_cast<int>(sessionState), sessionId,
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 	return ret;
 }
@@ -510,7 +522,10 @@ bool ContentProtectionFirebolt::SetPlaybackPosition(int64_t sessionId, float spe
 	else
 	{
 		// An error occurred, log the error
-		MW_LOG_ERR("SetPlaybackPosition failed to set for ID: %" PRId64 " Firebolt Error: \"%d\"", sessionId, static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("SetPlaybackPosition failed to set for ID: %" PRId64 " Firebolt Error: \"%d\" Message: %s", sessionId,
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 	return ret;
 }
@@ -534,7 +549,10 @@ void ContentProtectionFirebolt::ShowWatermark(bool show, int64_t sessionId)
 		MW_LOG_INFO("ShowWatermark visibility set successfully. Show: %d", show);
 	} else {
 		// An error occurred, log the error
-		MW_LOG_ERR("showWatermark failed. Firebolt Error: \"%d\"", static_cast<int>(result.error()));
+		const auto& info = result.errorInfo();
+		MW_LOG_ERR("showWatermark failed. Firebolt Error: \"%d\" Message: %s",
+			static_cast<int>(info.error()),
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 }
 static Firebolt::ContentProtection::KeySystem convertStringToKeySystem(const std::string& keySystemStr)
@@ -579,8 +597,10 @@ bool ContentProtectionFirebolt::OpenDrmSession(std::string& clientId, std::strin
 	}
 	else
 	{
-		  errorCode =  static_cast<int>(drmSession.error());
-		  MW_LOG_ERR("openDrmSession: Firebolt Error: \"%d\"", errorCode);
+		  const auto& info = drmSession.errorInfo();
+		  errorCode = static_cast<int>(info.error());
+		  MW_LOG_ERR("openDrmSession: Firebolt Error: \"%d\" Message: %s", errorCode,
+			  !info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 	return ret;
 }
@@ -605,8 +625,10 @@ bool ContentProtectionFirebolt::UpdateDrmSession(int64_t sessionId, int32_t &err
 	}
 	else
 	{
-		errorCode =  static_cast<int>(drmSession.error());
-		MW_LOG_ERR("updateDrmSession: Firebolt Error: \"%d\"", errorCode);
+		const auto& info = drmSession.errorInfo();
+		errorCode = static_cast<int>(info.error());
+		MW_LOG_ERR("updateDrmSession: Firebolt Error: \"%d\" Message: %s", errorCode,
+			!info.message().empty() ? info.message().c_str() : "No Firebolt error details available");
 	}
 	return ret;
 }


### PR DESCRIPTION
RDKEMW-16544 : string based firebolt error logging
Reason for change : integrate new errorToString API in firebolt for better logging
Test Steps : mentioned in ticket
Signed-off by : R.Naren [naren_ramesh@comcast.com](mailto:naren_ramesh@comcast.com)