### PR TITLE
RDKEMW-16544 : logger crash protection

### DIFF
--- a/externals/PlayerExternalUtils.h
+++ b/externals/PlayerExternalUtils.h
@@ -30,9 +30,11 @@
 
 #define MW_PRE_LOGGER_LOG(fmt, ...)                                            \
     do {                                                                    \
-        std::printf("[MIDDLEWARE] %s:%d %s: " fmt, __FILE__, __LINE__,      \
-                    __func__ , ##__VA_ARGS__);                              \
-        std::fflush(stdout);                                                \
+        if (stderr != nullptr) {                                            \
+            std::fprintf(stderr, "[PLAYER_IF] %s:%d %s: " fmt, __FILE__, __LINE__, \
+                         __func__ , ##__VA_ARGS__);                         \
+            std::fflush(stderr);                                            \
+        }                                                   \
     } while (0)
 
 


### PR DESCRIPTION
RDKEMW-16544 : logger crash protection
Reason for change : logger crashes when trying log before stderr/stdio ready
Test Steps: mentioned in ticket
SIgned-off by : R.Naren <naren_ramesh@comcast.com>