### PR TITLE
RDKEMW-20220:  Fix for the crash in "WPEWebProcess" during Deepsleep scenario

### DIFF
--- a/externals/rdk/IIarm/DeviceIARMInterface.cpp
+++ b/externals/rdk/IIarm/DeviceIARMInterface.cpp
@@ -38,13 +38,13 @@ Remove the entire folder externals/rdk/IARM
 #include <libIARM.h>
 #include <libIBus.h>
 #include <iarmUtil.h>
+#include <thread>
 #include "libIBusDaemon.h"
 #include <hostIf_tr69ReqHandler.h>
 #include "tr181api.h"
 #include "_base64.h"
 #ifdef USE_PREINIT_DECODING
 #include "power_controller.h"
-#include <thread>
 #include <system_error> // for std::system_error 
 #include <exception> // for std::exception base class
 #endif
@@ -244,6 +244,18 @@ static void IARM_PowerChangeHandler (const PowerController_PowerState_t currentS
 {
 	MW_LOG_INFO("Entering IARM_PowerChangeHandler:State Changed currentState: %d, newState: %d",
 			currentState, newState);
+	
+
+	std::shared_ptr<PlayerExternalsRdkInterface> pInstance =
+		PlayerExternalsRdkInterface::GetPlayerExternalsRdkInterfaceInstance();
+	if (newState != POWER_STATE_ON) {
+		pInstance->SetPowerEvent(true);
+		MW_LOG_INFO(" Power transition to non-ON state, blocking HDMI events\n");
+	} else {
+		pInstance->SetPowerEvent(false);
+		MW_LOG_INFO(" Power transition to ON, allowing HDMI events\n");
+	}
+
 	bool isOnOrStandby = (newState == POWER_STATE_STANDBY || newState == POWER_STATE_ON);
 	if((currentState == POWER_STATE_STANDBY_DEEP_SLEEP && isOnOrStandby) || 
         (prevState == POWER_STATE_STANDBY_DEEP_SLEEP && currentState == POWER_STATE_STANDBY_LIGHT_SLEEP && isOnOrStandby))
@@ -415,6 +427,12 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
 {
     std::shared_ptr<PlayerExternalsRdkInterface> pInstance = PlayerExternalsRdkInterface::GetPlayerExternalsRdkInterfaceInstance();
 
+
+    if (pInstance->GetPowerEvent())
+    {
+        MW_LOG_WARN(" Skipping HDMI event processing during power transition\n");
+        return;
+    }
     switch (eventId)
     {
         case IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG :
@@ -428,6 +446,10 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
 
             pInstance->SetHDMIStatus();
 
+	    // Dispatch to detached worker thread — do NOT block IARM dispatch thread
+            std::thread([pInstance]() {
+                pInstance->SetHDMIStatus();
+            }).detach();
             break;
         }
         case IARM_BUS_DSMGR_EVENT_HDCP_STATUS :
@@ -439,6 +461,9 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
                       hdcpStatus, hdcpStatusStr);
 
             pInstance->SetHDMIStatus();
+	    std::thread([pInstance]() {
+                pInstance->SetHDMIStatus();
+            }).detach();
             break;
         }
         default:

--- a/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -228,6 +228,11 @@ void PlayerExternalsRdkInterface::SetResolution(int width, int height)
  */
 void PlayerExternalsRdkInterface::SetHDMIStatus()
 {
+    std::unique_lock<std::mutex> lock(m_hdmiStatusMutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        MW_LOG_WARN("SetHDMIStatus: Already in progress on another thread, skipping\n");
+        return;
+    }
     bool                    isConnected              = false;
     bool                    isHDCPCompliant          = false;
     bool                    isHDCPEnabled            = true;
@@ -306,6 +311,7 @@ void PlayerExternalsRdkInterface::SetHDMIStatus()
     }
     catch (...) {
         MW_LOG_WARN("DeviceSettings unknown exception caught\n");
+	try { device::Manager::DeInitialize(); } catch (...) {} 
     }
 
     m_isHDCPEnabled = isHDCPEnabled;

--- a/externals/rdk/PlayerExternalsRdkInterface.h
+++ b/externals/rdk/PlayerExternalsRdkInterface.h
@@ -36,7 +36,7 @@
 
 #include <memory>
 #include "PlayerExternalsInterfaceBase.h"
-
+#include <mutex>
  /*
 IARM Deprecation Note:
 IARM is to be deprecated in favor of DeviceSettings and Firebolt Device API.
@@ -63,6 +63,7 @@ class PlayerExternalsRdkInterface : public PlayerExternalsInterfaceBase
 	, public device::Host::IVideoOutputPortEvents
 #endif
 {
+	std::mutex m_hdmiStatusMutex;
         enum InitState{
             NOT_INITIALIZED,
             FIREBOLT,


### PR DESCRIPTION
Update done to fix the crash that happens in deep sleep wakeup scenario , where the webprocess is unresponsive.

Once the HDMI hotplug event arrived, Instead of blocking the IARM thread with SetHDMIStatus() → dsDisplayInit → broken D-Bus, the callback would have returned immediately.
The spawned worker thread would have blocked on the broken IARM Bus, but this would NOT have caused the WPE watchdog to trigger SIGFPE, because the WebProcess main thread would have remained responsive.
This is the most impactful single fix for preventing the crash scenario observed.