### PR TITLE
RDKEMW-20795: Bring VPAAMP-457 changes to middleware-player-interface

### DIFF
--- a/subtec/subtecparser/WebVttSubtecParser.cpp
+++ b/subtec/subtecparser/WebVttSubtecParser.cpp
@@ -19,6 +19,7 @@
 
 #include "WebVttSubtecParser.hpp"
 #include "TextStyleAttributes.h"
+#include <cmath>
 
 WebVTTSubtecParser::WebVTTSubtecParser(SubtitleMimeType type, int width, int height) : SubtitleParser(type, width, height), m_channel(nullptr)
 {
@@ -70,9 +71,18 @@ bool WebVTTSubtecParser::processData(const char* buffer, size_t bufferLen, doubl
 	std::string str(const_cast<const char*>(buffer), bufferLen);
 	std::vector<uint8_t> data(str.begin(), str.end());
 
-	m_channel->SendDataPacket(std::move(data), 0);
+	m_channel->SendDataPacket(std::move(data), time_offset_ms_);
 
 	return true;
+}
+
+void WebVTTSubtecParser::setPtsOffset(double ptsOffsetSec)
+{
+	// Subtec's display_time = media_PTS - time_offset_ms (subtraction
+	// convention shared with Rialto SetSubtitlePtsOffset). The HLS
+	// restamped video PTS is media_PTS + ptsOffsetSec, so we negate
+	// here to make subtec add the offset on the subtitle path.
+	time_offset_ms_ = -static_cast<std::int64_t>(std::llround(ptsOffsetSec * 1000.0));
 }
 
 void WebVTTSubtecParser::mute(bool mute)

--- a/subtec/subtecparser/WebVttSubtecParser.hpp
+++ b/subtec/subtecparser/WebVttSubtecParser.hpp
@@ -40,9 +40,10 @@ public:
 	void pause(bool pause) override;
 	void mute(bool mute) override;
 	void setTextStyle(const std::string &options) override;
+	void setPtsOffset(double ptsOffsetSec) override;
 protected:
 	std::unique_ptr<SubtecChannel> m_channel;
 private:
-	std::uint64_t time_offset_ms_ = 0;
+	std::int64_t time_offset_ms_ = 0;
 	std::uint64_t start_ms_ = 0;
 };

--- a/subtitle/subtitleParser.h
+++ b/subtitle/subtitleParser.h
@@ -93,6 +93,15 @@ public:
 	virtual void mute(bool mute) {}
 	virtual void isLinear(bool isLinear) {}
 	virtual void setTextStyle(const std::string &options){}
+	/**
+	 * @brief Set a per-fragment PTS offset (seconds) that the parser
+	 *        applies when forwarding cue data to its subtitle sink.
+	 *
+	 * Used by the HLS PTS-restamp path to align subtitle display time
+	 * with the restamped video PTS without rewriting MPEGTS in the
+	 * VTT header. Default no-op; subtec-based parsers override.
+	 */
+	virtual void setPtsOffset(double ptsOffsetSec) {}
 	void RegisterCallback(const PlayerCallbacks& playerCallBack)
 	{
 		playerResumeTrackDownloads_CB = playerCallBack.resumeTrackDownloads_CB;

--- a/subtitle/subtitleParser.h
+++ b/subtitle/subtitleParser.h
@@ -99,7 +99,7 @@ public:
 	 *
 	 * Used by the HLS PTS-restamp path to align subtitle display time
 	 * with the restamped video PTS without rewriting MPEGTS in the
-	 * VTT header. Default no-op; subtec-based parsers override.
+	 * VTT header. Default no-op; parsers that need this behavior override.
 	 */
 	virtual void setPtsOffset(double ptsOffsetSec) {}
 	void RegisterCallback(const PlayerCallbacks& playerCallBack)


### PR DESCRIPTION
Aamp commit 2da7d5d

Instead of rewriting the MPEGTS field in the VTT byte stream (fragile header surgery), the PTS offset is pushed into the subtec channel as a signed time offset, matching the pattern already used on the DASH path.

- subtitleParser.h: add virtual setPtsOffset(double) no-op to base class
- WebVttSubtecParser.hpp: declare setPtsOffset override; change time_offset_ms_ to signed int64_t
- WebVttSubtecParser.cpp: implement setPtsOffset; pass time_offset_ms_ to SendDataPacket

Cherry-picked from rdkcentral/aamp@2da7d5d8324c1bab81e24ea3d64c9a21eed6f2f7