### PR TITLE
RDKEMW-20975 [Rack][RDKE][8.6][Llama G1/Cello]: Screen got stuck during VOD content playback

### DIFF
--- a/InterfacePlayerPriv.h
+++ b/InterfacePlayerPriv.h
@@ -41,7 +41,7 @@
 #include "InterfacePlayerRDK.h"
 #include "GstUtils.h"
 
-#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 10
+#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 5
 #define GST_TRACK_COUNT 3 /**< internal use - audio+video+sub track */
 #define VIDEO_COORDINATES_SIZE 32
 #define GST_TASK_ID_INVALID 0

--- a/InterfacePlayerPriv.h
+++ b/InterfacePlayerPriv.h
@@ -41,7 +41,7 @@
 #include "InterfacePlayerRDK.h"
 #include "GstUtils.h"
 
-#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 5
+#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 10
 #define GST_TRACK_COUNT 3 /**< internal use - audio+video+sub track */
 #define VIDEO_COORDINATES_SIZE 32
 #define GST_TASK_ID_INVALID 0

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -3441,12 +3441,14 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 			/* wait a bit longer for the state change to conclude */
 			if (nextState != validateStateWithMsTimeout(this,nextState, 100))
 			{
-				MW_LOG_ERR("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED GstState %d", nextState);
+				MW_LOG_ERR("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED GstState %d ret-false", nextState);
+				retValue = false;
 			}
 		}
 		else if (GST_STATE_CHANGE_SUCCESS != rc)
 		{
-			MW_LOG_ERR("InterfacePlayerRDK_Pause - gst_element_set_state - FAILED rc %d", rc);
+			MW_LOG_ERR("InterfacePlayerRDK_Pause - gst_element_set_state - FAILED rc %d ret-false", rc);
+			retValue = false;
 		}
 		
 		interfacePlayerPriv->gstPrivateContext->buffering_target_state = nextState;

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -1581,7 +1581,7 @@ bool InterfacePlayerRDK::IsUsingRialtoSink()
 /**
  *  @brief Flush cached GstBuffers and set seek position & rate
  */
-bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek)
+bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek, bool keepPausedSeek)
 {
 	GstState aud_current;
 	GstState aud_pending;
@@ -1634,6 +1634,12 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	}
 	GstStateChangeReturn ret;
 	ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 100 * GST_MSECOND);
+	if (GST_STATE_CHANGE_ASYNC == ret && keepPausedSeek)
+	{
+		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
+			gst_element_state_get_name(current), gst_element_state_get_name(pending));
+		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
+	}
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Pipeline state %s, ret %u", gst_element_state_get_name(current), ret);

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -1638,7 +1638,7 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
 			gst_element_state_get_name(current), gst_element_state_get_name(pending));
-		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
+		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 500 * GST_MSECOND);
 	}
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -1634,7 +1634,12 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	}
 	GstStateChangeReturn ret;
 	ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 100 * GST_MSECOND);
-	
+	if (GST_STATE_CHANGE_ASYNC == ret && keepPausedSeek)
+	{
+		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
+			gst_element_state_get_name(current), gst_element_state_get_name(pending));
+		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
+	}
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Pipeline state %s, ret %u", gst_element_state_get_name(current), ret);
@@ -3432,22 +3437,6 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 			 * and the resume play will be handled from StopBuffering once after getting enough buffer/frames.
 			 */
 			interfacePlayerPriv->gstPrivateContext->buffering_in_progress = false;
-		}
-		
-		if (GST_STATE_PLAYING == nextState)
-		{
-			GstState curState, pendState;
-			if (GST_STATE_CHANGE_ASYNC ==
-				gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline,
-									  &curState, &pendState, 0))
-			{
-				MW_LOG_WARN("InterfacePlayerRDK_Pause: resume during in-flight transition "
-							"(current=%s pending=%s) - settling before PLAYING",
-							gst_element_state_get_name(curState),
-							gst_element_state_get_name(pendState));
-				gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline,
-									  &curState, &pendState, 300 * GST_MSECOND);
-			}
 		}
 
 		GstStateChangeReturn rc = SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, nextState);

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -1634,12 +1634,7 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	}
 	GstStateChangeReturn ret;
 	ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 100 * GST_MSECOND);
-	if (GST_STATE_CHANGE_ASYNC == ret && keepPausedSeek)
-	{
-		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
-			gst_element_state_get_name(current), gst_element_state_get_name(pending));
-		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
-	}
+	
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Pipeline state %s, ret %u", gst_element_state_get_name(current), ret);
@@ -3437,6 +3432,22 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 			 * and the resume play will be handled from StopBuffering once after getting enough buffer/frames.
 			 */
 			interfacePlayerPriv->gstPrivateContext->buffering_in_progress = false;
+		}
+		
+		if (GST_STATE_PLAYING == nextState)
+		{
+			GstState curState, pendState;
+			if (GST_STATE_CHANGE_ASYNC ==
+				gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline,
+									  &curState, &pendState, 0))
+			{
+				MW_LOG_WARN("InterfacePlayerRDK_Pause: resume during in-flight transition "
+							"(current=%s pending=%s) - settling before PLAYING",
+							gst_element_state_get_name(curState),
+							gst_element_state_get_name(pendState));
+				gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline,
+									  &curState, &pendState, 300 * GST_MSECOND);
+			}
 		}
 
 		GstStateChangeReturn rc = SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, nextState);

--- a/InterfacePlayerRDK.cpp
+++ b/InterfacePlayerRDK.cpp
@@ -1638,7 +1638,7 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
 			gst_element_state_get_name(current), gst_element_state_get_name(pending));
-		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 500 * GST_MSECOND);
+		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
 	}
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{

--- a/InterfacePlayerRDK.h
+++ b/InterfacePlayerRDK.h
@@ -716,8 +716,9 @@ class InterfacePlayerRDK
         	 * @param[in] shouldTearDown Whether to tear down the pipeline.
         	 * @param[in] GstState The desired GStreamer pipeline state.
         	 * @param[in] gstMediaFormat The media format for the pipeline.
+			 * @param[in] keepPausedSeek true only for an explicit seek-with-keepPaused request
         	 */
-        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek);
+        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek,  bool keepPausedSeek);
         	/**
         	 * @fn TimerAdd
         	 * @param[in] funcPtr function to execute on timer expiry


### PR DESCRIPTION
Race Condition Recovery Handling Summary
To address the playback freeze caused by race conditions, the recovery handling has been implemented across both the Middleware and AAMP layers.

Middleware Changes
Propagate Pause() failure

Pause() detects the failure through validateStateWithMsTimeout(), but the failure was not being propagated to the middleware layer.
The fix ensures that the failure is propagated instead of being silently ignored.
Increase timeout budget

Previously, mSinkPaused was being set to false unconditionally, even when Pause() failed, resulting in a state mismatch that masked the playback freeze during subsequent SetRate() calls.
The state handling has been corrected to avoid this desynchronization.
AAMP Changes
Recover by re-tuning

Once the middleware propagates the Pause() failure, AAMP now schedules a recovery by performing a re-tune instead of continuing in a broken state.
This ensures playback recovery when the race condition is encountered.
Additional Linear Playback Handling
After implementing the above changes, VOD playback recovered successfully with approximately 1 second recovery time. However, linear playback still exhibited issues.

To address this, the AAMP handling was updated in the pipeline-unpause branch:
https://github.com/rdkcentral/aamp/pull/1723

When Pause(false) fails, trigger recovery using TuneHelper(eTUNETYPE_SEEK), matching the existing Local-TSB recovery path.
Keep mSinkPaused = false and ResumeDownloads() unconditional as part of the recovery flow.
Result
VOD Playback: Successfully recovers without playback freeze (approximately 1-second recovery).
Linear Playback: Successfully recovers after applying the additional AAMP handling.
Note: The recovery logic is implemented collaboratively across both the Middleware and AAMP layers. When the race condition is detected and Pause() fails, the failure is propagated and appropriate recovery actions are triggered, allowing both VOD and Linear playback to recover automatically.