### PR TITLE
RDKEMW-21167 aamp - dev_sprint_25_2 simulator built using new external middleware rep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_aamp/
 .libs/
 
 sync/aamp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ pkg_check_modules(GSTREAMERBASE REQUIRED gstreamer-app-1.0)
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 	include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 else()
-	include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS})
+	include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 #include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
@@ -139,7 +139,10 @@ else()
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-	set(GSTREAMER_LINK_LIBRARIES "")
+	# Zero out short-name library variables that require link_directories() to resolve.
+	# The Xcode generator appends $(CONFIGURATION) to link_directories() paths, causing
+	# spurious "search path not found" warnings. Full-path _LINK_LIBRARIES variables are
+	# used instead via separate target_link_libraries() calls below.
 	set(GST_LIBRARIES "")
 	set(GSTREAMERBASE_LIBRARIES "")
 	set(GSTVIDEO_LIBRARIES "")
@@ -443,9 +446,9 @@ endif()
 
 target_link_libraries(playergstinterface ${LIBPLAYERGSTINTERFACE_DEPENDS})
 
-target_link_libraries(playergstinterface ${GST_LIBRARIES} ${GSTREAMER_LIBRARIES} ${GSTREAMERBASE_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
+target_link_libraries(playergstinterface ${GST_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
 
-target_link_libraries(playergstinterface ${GSTVIDEO_LIBRARIES} ${LIBPLAYERGSTINTERFACE_DEPENDS})
+target_link_libraries(playergstinterface ${GSTREAMERVIDEO_LINK_LIBRARIES})
 
 set_target_properties(playergstinterface PROPERTIES COMPILE_FLAGS "${LIBPLAYERGSTINTERFACE_DEFINES} ${OS_CXX_FLAGS}")
 
@@ -468,7 +471,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libplayergstinterface.pc"
 	)
 
 target_link_libraries(subtec playerlogmanager)
-target_link_libraries(playergstinterface ${GSTVIDEO_LIBRARIES} ${LIBPLAYERGSTINTERFACE_DEPENDS})
 target_link_libraries(playergstinterface subtec)
 target_link_libraries(playergstinterface baseconversion)
 target_link_libraries(playergstinterface playerfbinterface)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -56,15 +56,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/rdk/IFirebolt)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/IFirebolt)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    # Remove any pkg-config based GStreamer link libraries
-    set(GSTREAMER_LINK_LIBRARIES "")
-    set(GST_LIBRARIES "")
-    set(GSTREAMERBASE_LINK_LIBRARIES "")
-    set(GSTVIDEO_LINK_LIBRARIES "")
-    # Add GStreamer.framework to linker flags
-    set(OS_LD_FLAGS)
-    list(APPEND OS_LD_FLAGS -F/Library/Frameworks "-framework GStreamer")
-    list(APPEND LIB_EXT_DEPENDS ${OS_LD_FLAGS})
+    # Use full-path _LINK_LIBRARIES (Homebrew dylibs) instead of -framework GStreamer.
+    # The framework install is no longer required; Homebrew gstreamer provides the dylibs
+    # and pkg_check_modules populates _LINK_LIBRARIES with absolute paths that the linker
+    # can resolve without link_directories().
+    list(APPEND LIB_EXT_DEPENDS ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
 else()
     list(APPEND LIB_EXT_DEPENDS ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
 endif()

--- a/gst-plugins/CMakeLists.txt
+++ b/gst-plugins/CMakeLists.txt
@@ -35,7 +35,10 @@ pkg_check_modules(CURL REQUIRED libcurl)
 # Mac OS X
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     pkg_check_modules(GSTREAMERVIDEO REQUIRED gstreamer-video-1.0)
-    link_directories(${GSTREAMERVIDEO_LIBRARY_DIRS})
+    # link_directories(${GSTREAMERVIDEO_LIBRARY_DIRS}) omitted: the Xcode generator
+    # appends $(CONFIGURATION) to these paths, causing spurious "search path
+    # not found" warnings for non-existent .../lib/Debug directories.
+    pkg_check_modules(UUID REQUIRED uuid)
     set(OS_CXX_FLAGS "${OS_CXX_FLAGS} -g -x objective-c++")
     set(OS_LD_FLAGS "${OS_LD_FLAGS} -framework Cocoa")
     string(STRIP "${OS_LD_FLAGS}" OS_LD_FLAGS)
@@ -53,7 +56,12 @@ include_directories(${GSTREAMERBASE_INCLUDE_DIRS})
 include_directories(${MW_ROOT}/closedcaptions)
 include_directories(${MW_ROOT}/)
 
-set(GST_COMMON_DEPENDENCIES ${OS_LD_FLAGS} ${GSTREAMERBASE_LIBRARIES} ${GSTREAMER_LIBRARIES} ${CURL_LIBRARIES} ${CLI_LD_FLAGS} -ldl -luuid ${SEC_CLIENT_LIB})
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # On Darwin use full-path _LINK_LIBRARIES to avoid needing link_directories().
+    set(GST_COMMON_DEPENDENCIES ${OS_LD_FLAGS} ${GSTREAMERBASE_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES} ${CURL_LINK_LIBRARIES} ${UUID_LINK_LIBRARIES} ${CLI_LD_FLAGS} ${SEC_CLIENT_LIB})
+else()
+    set(GST_COMMON_DEPENDENCIES ${OS_LD_FLAGS} ${GSTREAMERBASE_LIBRARIES} ${GSTREAMER_LIBRARIES} ${CURL_LIBRARIES} ${CLI_LD_FLAGS} -ldl -luuid ${SEC_CLIENT_LIB})
+endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-multichar")
 

--- a/gst-plugins/gst_subtec/CMakeLists.txt
+++ b/gst-plugins/gst_subtec/CMakeLists.txt
@@ -30,19 +30,22 @@ include_directories(${GSTREAMER_INCLUDE_DIRS})
 include_directories(${GSTREAMERBASE_INCLUDE_DIRS})
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../middleware/subtec/libsubtec)
-    link_directories(${GSTREAMERBASE_LIBRARY_DIRS} ${GSTREAMER_LIBRARY_DIRS})
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../subtec/libsubtec)
+    # link_directories(${GSTREAMERBASE_LIBRARY_DIRS} ${GSTREAMER_LIBRARY_DIRS}) omitted:
+    # the Xcode generator appends $(CONFIGURATION) to these paths, producing spurious
+    # "search path not found" warnings for non-existent .../lib/Debug directories.
+    # Full-path _LINK_LIBRARIES variables are used instead (see GSTSUBTEC_DEPENDENCIES below).
     link_directories(${CMAKE_INSTALL_PREFIX})
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-multichar -DSUBTEC_PACKET_DEBUG")
 
-set(GSTSUBTEC_DEPENDENCIES ${GSTREAMERBASE_LIBRARIES} ${GSTREAMER_LIBRARIES})
+set(GSTSUBTEC_DEPENDENCIES ${GSTREAMERBASE_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES})
 
 add_library(gstsubtecsink SHARED gstsubtecsink.cpp)
 
 message(STATUS "GSTSUBTEC_DEPENDENCIES: ${GSTSUBTEC_DEPENDENCIES}")
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../middleware/subtec/libsubtec)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../subtec/libsubtec)
 target_link_libraries(gstsubtecsink PRIVATE subtec ${GSTSUBTEC_DEPENDENCIES})
 
 add_library(gstsubtecbin SHARED gstsubtecbin.cpp)


### PR DESCRIPTION
his commit adapts the macOS/Darwin build system for the AAMP simulator to work with the new external middleware-player-interface repository. The key changes:

Replaced link_directories() with full-path _LINK_LIBRARIES variables – CMake's Xcode generator appends $(CONFIGURATION) to link_directories() paths, creating bogus paths like .../lib/Debug. Using absolute dylib paths from pkg-config avoids this.

Switched from GStreamer.framework to Homebrew dylibs – No longer requires a separate GStreamer framework installation; uses Homebrew-provided libraries instead.

Fixed relative include paths – Updated ../../../middleware/subtec → ../../subtec to reflect the new repo layout.

Added missing dependencies – OpenSSL includes for non-Linux builds, uuid pkg-config module for macOS.

Removed duplicate target_link_libraries call and added build_aamp/ to .gitignore.

Added missing setPtsOffset virtual method to complete the player interface.